### PR TITLE
Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,14 @@ path = "src/lib.rs"
 name = "petname"
 path = "src/main.rs"
 doc = false
-required-features = ["clap"]
+required-features = ["clap", "std_rng", "default_dictionary"]
 
 [features]
-default = ["std_rng"]
+default = ["std_rng", "default_dictionary"]
+# Allows generating petnames with thread rng.
 std_rng = ["rand/std", "rand/std_rng"]
+# Allows the default dictionary to be used.
+default_dictionary = []
 
 [dependencies]
 clap = { version = "^2.33.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Generate human readable random names. Usable as a library and fro
 readme = "README.md"
 repository = "https://github.com/allenap/rust-petname"
 license = "Apache-2.0"
-categories = ["command-line-utilities"]
+categories = ["command-line-utilities", "no-std"]
 keywords = ["pet", "name", "rand", "random", "generator"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ doc = false
 required-features = ["clap", "std_rng", "default_dictionary"]
 
 [features]
-default = ["std_rng", "default_dictionary"]
+# We include features that must be used for the binary regardless of if they are used (like clap).
+default = ["clap", "std_rng", "default_dictionary"]
 # Allows generating petnames with thread rng.
 std_rng = ["rand/std", "rand/std_rng"]
 # Allows the default dictionary to be used.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/allenap/rust-petname"
 license = "Apache-2.0"
 categories = ["command-line-utilities"]
+keywords = ["pet", "name", "rand", "random", "generator"]
 
 [badges]
 travis-ci = { repository = "allenap/rust-petname", branch = "master" }
@@ -20,8 +21,13 @@ path = "src/lib.rs"
 name = "petname"
 path = "src/main.rs"
 doc = false
+required-features = ["clap"]
+
+[features]
+default = ["std_rng"]
+std_rng = ["rand/std", "rand/std_rng"]
 
 [dependencies]
-clap = "^2.33.0"
-itertools = "^0.9.0"
-rand = "^0.8.0"
+clap = { version = "^2.33.0", default-features = false, optional = true }
+itertools = { version = "^0.9.0", default-features = false }
+rand = { version = "^0.8.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,13 +312,13 @@ mod tests {
     #[test]
     #[cfg(feature = "std_rng")]
     fn petname_renders_desired_number_of_words() {
-        assert_eq!(petname(7, "-").split("-").count(), 7);
+        assert_eq!(petname(7, "-").split('-').count(), 7);
     }
 
     #[test]
     #[cfg(feature = "std_rng")]
     fn petname_renders_with_desired_separator() {
-        assert_eq!(petname(7, "@").split("@").count(), 7);
+        assert_eq!(petname(7, "@").split('@').count(), 7);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 
@@ -257,98 +266,5 @@ where
             self.petnames
                 .generate(self.rng, self.words, &self.separator),
         )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
-    use super::petname;
-    use super::Petnames;
-    use rand::rngs::mock::StepRng;
-
-    #[test]
-    #[cfg(feature = "default_dictionary")]
-    fn default_petnames_has_adjectives() {
-        let petnames = Petnames::default();
-        assert_ne!(petnames.adjectives.len(), 0);
-    }
-
-    #[test]
-    #[cfg(feature = "default_dictionary")]
-    fn default_petnames_has_adverbs() {
-        let petnames = Petnames::default();
-        assert_ne!(petnames.adverbs.len(), 0);
-    }
-
-    #[test]
-    #[cfg(feature = "default_dictionary")]
-    fn default_petnames_has_names() {
-        let petnames = Petnames::default();
-        assert_ne!(petnames.names.len(), 0);
-    }
-
-    #[test]
-    fn retain_applies_given_predicate() {
-        let petnames_expected = Petnames::init("bob", "bob", "bob jane");
-        let mut petnames = Petnames::init("alice bob carol", "alice bob", "bob carol jane");
-        petnames.retain(|word| word.len() < 5);
-        assert_eq!(petnames_expected, petnames);
-    }
-
-    #[test]
-    #[cfg(feature = "default_dictionary")]
-    fn default_petnames_has_non_zero_cardinality() {
-        let petnames = Petnames::default();
-        // This test will need to be adjusted when word lists change.
-        assert_eq!(0, petnames.cardinality(0));
-        assert_eq!(456, petnames.cardinality(1));
-        assert_eq!(204744, petnames.cardinality(2));
-        assert_eq!(53438184, petnames.cardinality(3));
-        assert_eq!(13947366024, petnames.cardinality(4));
-    }
-
-    #[test]
-    fn generate_uses_adverb_adjective_name() {
-        let petnames = Petnames {
-            adjectives: vec!["adjective"],
-            adverbs: vec!["adverb"],
-            names: vec!["name"],
-        };
-        assert_eq!(
-            petnames.generate(&mut StepRng::new(0, 1), 3, "-"),
-            "adverb-adjective-name"
-        );
-    }
-
-    #[test]
-    #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
-    fn petname_renders_desired_number_of_words() {
-        assert_eq!(petname(7, "-").split('-').count(), 7);
-    }
-
-    #[test]
-    #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
-    fn petname_renders_with_desired_separator() {
-        assert_eq!(petname(7, "@").split('@').count(), 7);
-    }
-
-    #[test]
-    fn petnames_iter_has_cardinality() {
-        let mut rng = StepRng::new(0, 1);
-        let petnames = Petnames::init("a b", "c d e", "f g h i");
-        let names = petnames.iter(&mut rng, 3, ".");
-        assert_eq!(24u128, names.cardinality());
-    }
-
-    #[test]
-    fn petnames_iter_yields_names() {
-        let mut rng = StepRng::new(0, 1);
-        let petnames = Petnames::init("foo", "bar", "baz");
-        let names = petnames.iter(&mut rng, 3, ".");
-        // Definintely an Iterator...
-        let mut iter: Box<dyn Iterator<Item = _>> = Box::new(names);
-        assert_eq!(Some("bar.foo.baz".to_string()), iter.next());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,9 @@ use rand::seq::SliceRandom;
 /// Convenience function to generate a new petname from default word lists.
 #[allow(dead_code)]
 #[cfg(feature = "std_rng")]
+#[cfg(feature = "default_dictionary")]
 pub fn petname(words: u8, separator: &str) -> String {
-    Petnames::default().generate_one(words, separator)
+    Petnames::new().generate_one(words, separator)
 }
 
 /// A word list.
@@ -28,11 +29,13 @@ pub struct Petnames<'a> {
 
 impl<'a> Petnames<'a> {
     /// Constructs a new `Petnames` from the default (small) word lists.
-    pub fn default() -> Self {
-        Self::small()
+    #[cfg(feature = "default_dictionary")]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Constructs a new `Petnames` from the small word lists.
+    #[cfg(feature = "default_dictionary")]
     pub fn small() -> Self {
         Self::init(
             include_str!("../words/small/adjectives.txt"),
@@ -42,6 +45,7 @@ impl<'a> Petnames<'a> {
     }
 
     /// Constructs a new `Petnames` from the medium word lists.
+    #[cfg(feature = "default_dictionary")]
     pub fn medium() -> Self {
         Self::init(
             include_str!("../words/medium/adjectives.txt"),
@@ -51,6 +55,7 @@ impl<'a> Petnames<'a> {
     }
 
     /// Constructs a new `Petnames` from the large word lists.
+    #[cfg(feature = "default_dictionary")]
     pub fn large() -> Self {
         Self::init(
             include_str!("../words/large/adjectives.txt"),
@@ -75,8 +80,11 @@ impl<'a> Petnames<'a> {
     /// # Examples
     ///
     /// ```rust
+    /// # #[cfg(feature = "default_dictionary")]
     /// let mut petnames = petname::Petnames::default();
+    /// # #[cfg(feature = "default_dictionary")]
     /// petnames.retain(|s| s.starts_with("b"));
+    /// # #[cfg(feature = "default_dictionary")]
     /// # #[cfg(feature = "std_rng")]
     /// petnames.generate_one(2, ".");
     /// ```
@@ -113,9 +121,9 @@ impl<'a> Petnames<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # #[cfg(feature = "std_rng")]
+    /// # #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     /// let mut rng = rand::thread_rng();
-    /// # #[cfg(feature = "std_rng")]
+    /// # #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     /// petname::Petnames::default().generate(&mut rng, 7, ":");
     /// ```
     ///
@@ -151,13 +159,13 @@ impl<'a> Petnames<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # #[cfg(feature = "std_rng")]
+    /// # #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     /// let mut rng = rand::thread_rng();
-    /// # #[cfg(feature = "std_rng")]
+    /// # #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     /// let petnames = petname::Petnames::default();
-    /// # #[cfg(feature = "std_rng")]
+    /// # #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     /// let mut iter = petnames.iter(&mut rng, 4, "_");
-    /// # #[cfg(feature = "std_rng")]
+    /// # #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     /// println!("name: {}", iter.next().unwrap());
     /// ```
     ///
@@ -174,9 +182,10 @@ impl<'a> Petnames<'a> {
     }
 }
 
+#[cfg(feature = "default_dictionary")]
 impl<'a> Default for Petnames<'a> {
     fn default() -> Self {
-        Self::default()
+        Self::small()
     }
 }
 
@@ -254,24 +263,27 @@ where
 #[cfg(test)]
 mod tests {
 
-    #[cfg(feature = "std_rng")]
+    #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     use super::petname;
     use super::Petnames;
     use rand::rngs::mock::StepRng;
 
     #[test]
+    #[cfg(feature = "default_dictionary")]
     fn default_petnames_has_adjectives() {
         let petnames = Petnames::default();
         assert_ne!(petnames.adjectives.len(), 0);
     }
 
     #[test]
+    #[cfg(feature = "default_dictionary")]
     fn default_petnames_has_adverbs() {
         let petnames = Petnames::default();
         assert_ne!(petnames.adverbs.len(), 0);
     }
 
     #[test]
+    #[cfg(feature = "default_dictionary")]
     fn default_petnames_has_names() {
         let petnames = Petnames::default();
         assert_ne!(petnames.names.len(), 0);
@@ -286,6 +298,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "default_dictionary")]
     fn default_petnames_has_non_zero_cardinality() {
         let petnames = Petnames::default();
         // This test will need to be adjusted when word lists change.
@@ -310,13 +323,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std_rng")]
+    #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     fn petname_renders_desired_number_of_words() {
         assert_eq!(petname(7, "-").split('-').count(), 7);
     }
 
     #[test]
-    #[cfg(feature = "std_rng")]
+    #[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
     fn petname_renders_with_desired_separator() {
         assert_eq!(petname(7, "@").split('@').count(), 7);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use rand::seq::SliceRandom;
 
 /// Convenience function to generate a new petname from default word lists.
 #[allow(dead_code)]
+#[cfg(feature = "std_rng")]
 pub fn petname(words: u8, separator: &str) -> String {
     Petnames::default().generate_one(words, separator)
 }
@@ -76,6 +77,7 @@ impl<'a> Petnames<'a> {
     /// ```rust
     /// let mut petnames = petname::Petnames::default();
     /// petnames.retain(|s| s.starts_with("b"));
+    /// # #[cfg(feature = "std_rng")]
     /// petnames.generate_one(2, ".");
     /// ```
     ///
@@ -111,7 +113,9 @@ impl<'a> Petnames<'a> {
     /// # Examples
     ///
     /// ```rust
+    /// # #[cfg(feature = "std_rng")]
     /// let mut rng = rand::thread_rng();
+    /// # #[cfg(feature = "std_rng")]
     /// petname::Petnames::default().generate(&mut rng, 7, ":");
     /// ```
     ///
@@ -137,6 +141,7 @@ impl<'a> Petnames<'a> {
     /// This is like `generate` but uses `rand::thread_rng` as the random
     /// source. For efficiency use `generate` when creating multiple names, or
     /// when you want to use a custom source of randomness.
+    #[cfg(feature = "std_rng")]
     pub fn generate_one(&self, words: u8, separator: &str) -> String {
         self.generate(&mut rand::thread_rng(), words, separator)
     }
@@ -146,9 +151,13 @@ impl<'a> Petnames<'a> {
     /// # Examples
     ///
     /// ```rust
+    /// # #[cfg(feature = "std_rng")]
     /// let mut rng = rand::thread_rng();
+    /// # #[cfg(feature = "std_rng")]
     /// let petnames = petname::Petnames::default();
+    /// # #[cfg(feature = "std_rng")]
     /// let mut iter = petnames.iter(&mut rng, 4, "_");
+    /// # #[cfg(feature = "std_rng")]
     /// println!("name: {}", iter.next().unwrap());
     /// ```
     ///
@@ -245,7 +254,9 @@ where
 #[cfg(test)]
 mod tests {
 
-    use super::{petname, Petnames};
+    #[cfg(feature = "std_rng")]
+    use super::petname;
+    use super::Petnames;
     use rand::rngs::mock::StepRng;
 
     #[test]
@@ -299,11 +310,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std_rng")]
     fn petname_renders_desired_number_of_words() {
         assert_eq!(petname(7, "-").split("-").count(), 7);
     }
 
     #[test]
+    #[cfg(feature = "std_rng")]
     fn petname_renders_with_desired_separator() {
         assert_eq!(petname(7, "@").split("@").count(), 7);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 #[macro_use]
 extern crate clap;
 
-mod lib;
-use lib::Petnames;
+use petname::Petnames;
 
 use std::collections::HashSet;
 use std::fmt;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,88 @@
+#[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
+use petname::petname;
+use petname::Petnames;
+use rand::rngs::mock::StepRng;
+
+#[test]
+#[cfg(feature = "default_dictionary")]
+fn default_petnames_has_adjectives() {
+    let petnames = Petnames::default();
+    assert_ne!(petnames.adjectives.len(), 0);
+}
+
+#[test]
+#[cfg(feature = "default_dictionary")]
+fn default_petnames_has_adverbs() {
+    let petnames = Petnames::default();
+    assert_ne!(petnames.adverbs.len(), 0);
+}
+
+#[test]
+#[cfg(feature = "default_dictionary")]
+fn default_petnames_has_names() {
+    let petnames = Petnames::default();
+    assert_ne!(petnames.names.len(), 0);
+}
+
+#[test]
+fn retain_applies_given_predicate() {
+    let petnames_expected = Petnames::init("bob", "bob", "bob jane");
+    let mut petnames = Petnames::init("alice bob carol", "alice bob", "bob carol jane");
+    petnames.retain(|word| word.len() < 5);
+    assert_eq!(petnames_expected, petnames);
+}
+
+#[test]
+#[cfg(feature = "default_dictionary")]
+fn default_petnames_has_non_zero_cardinality() {
+    let petnames = Petnames::default();
+    // This test will need to be adjusted when word lists change.
+    assert_eq!(0, petnames.cardinality(0));
+    assert_eq!(456, petnames.cardinality(1));
+    assert_eq!(204744, petnames.cardinality(2));
+    assert_eq!(53438184, petnames.cardinality(3));
+    assert_eq!(13947366024, petnames.cardinality(4));
+}
+
+#[test]
+fn generate_uses_adverb_adjective_name() {
+    let petnames = Petnames {
+        adjectives: vec!["adjective"],
+        adverbs: vec!["adverb"],
+        names: vec!["name"],
+    };
+    assert_eq!(
+        petnames.generate(&mut StepRng::new(0, 1), 3, "-"),
+        "adverb-adjective-name"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
+fn petname_renders_desired_number_of_words() {
+    assert_eq!(petname(7, "-").split('-').count(), 7);
+}
+
+#[test]
+#[cfg(all(feature = "std_rng", feature = "default_dictionary"))]
+fn petname_renders_with_desired_separator() {
+    assert_eq!(petname(7, "@").split('@').count(), 7);
+}
+
+#[test]
+fn petnames_iter_has_cardinality() {
+    let mut rng = StepRng::new(0, 1);
+    let petnames = Petnames::init("a b", "c d e", "f g h i");
+    let names = petnames.iter(&mut rng, 3, ".");
+    assert_eq!(24u128, names.cardinality());
+}
+
+#[test]
+fn petnames_iter_yields_names() {
+    let mut rng = StepRng::new(0, 1);
+    let petnames = Petnames::init("foo", "bar", "baz");
+    let names = petnames.iter(&mut rng, 3, ".");
+    // Definintely an Iterator...
+    let mut iter: Box<dyn Iterator<Item = _>> = Box::new(names);
+    assert_eq!(Some("bar.foo.baz".to_string()), iter.next());
+}


### PR DESCRIPTION
This adds feature gates for several of the crate's capabilities.

One oddity is that we have to include the `clap` dependency by default, but it can be removed using `default-features = false`. This is despite that it isn't used in the library. The reason is that otherwise to build the `petname` executable, we would have to do `cargo install --features clap petname`. I assumed that this was not desirable, so I left clap as a default feature.

Let me know if any changes are necessary.

Closes #34.