### PR TITLE
Add Chosen Character Alliteration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         .arg(
             Arg::with_name("alliterate-with")
                 .long("alliterate-with")
+                .short("A")
                 .value_name("LETTER")
                 .help("Generate names where each word begins with the given letter")
                 .takes_value(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,9 @@ fn run(matches: clap::ArgMatches) -> Result<(), Error> {
 
     // Optional arguments without defaults.
     let opt_directory = matches.value_of("directory");
-    let opt_alliterate_char = matches.value_of("alliterate-with");
+    let opt_alliterate_char = matches
+        .value_of("alliterate-with")
+        .and_then(|s| s.parse::<char>().ok());
 
     // Parse numbers. Validated so unwrapping is okay.
     let opt_words: u8 = opt_words.parse().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,9 +215,7 @@ fn run(matches: clap::ArgMatches) -> Result<(), Error> {
         // if a specific character was requested for alliteration,
         // attempt to use it.
         if let Some(c) = opt_alliterate_char {
-            // alliteration character is validated to not be empty
-            let ch = c.chars().next().unwrap();
-            if firsts.contains(&ch) {
+            if firsts.contains(&c) {
                 petnames.retain(|s| s.starts_with(c));
             } else {
                 return Err(Error::Alliteration(


### PR DESCRIPTION
This closes #41, which requested the ability to specify an alliteration character instead of one being chosen at random.

Short option "-A" and long option "--alliterate-with" are added for this change.  Similar testing of the wordlist as with random alliteration is performed to ensure that this provides an error message if all potential names are eliminated by the chosen prefix.