### PR TITLE
Limit docs.rs builds to a single tier one target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ default_dictionary = []
 clap = { version = "^2.33.0", default-features = false, optional = true }
 itertools = { version = "^0.9.0", default-features = false }
 rand = { version = "^0.8.0", default-features = false }
+
+[package.metadata.docs.rs]
+# Limit docs.rs builds to a single tier one target, because they're identical on
+# all. https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html
+targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
At present, docs are identical on all platforms.

https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html

Fixes #30.