### PR TITLE
Add various refactorings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl<'a> Default for Petnames<'a> {
 /// your petname, this will first yield the adverbs word list, then adjectives,
 /// then names.
 #[derive(Debug, PartialEq)]
-pub(crate) enum Lists<'a> {
+enum Lists<'a> {
     Adverb(&'a Petnames<'a>, u8),
     Adjective(&'a Petnames<'a>),
     Name(&'a Petnames<'a>),


### PR DESCRIPTION
Highlights:

- Replace the Lists implementation with a more verbose, enum-based one
- Simplify control flow for `impl Iterator for NamesProduct` using the `?` operator and other tricks