### PR TITLE
Proposal: replace barebones clap parsing with structopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ path = "src/lib.rs"
 name = "petname"
 path = "src/main.rs"
 doc = false
-required-features = ["structopt", "std_rng", "default_dictionary"]
+required-features = ["clap", "std_rng", "default_dictionary"]
 
 [features]
 # We include features that must be used for the binary regardless of if they are used (like clap).
-default = ["structopt", "std_rng", "default_dictionary"]
+default = ["clap", "std_rng", "default_dictionary"]
+# Alias for backward compatibility.
+clap = ["structopt"]
 # Allows generating petnames with thread rng.
 std_rng = ["rand/std", "rand/std_rng"]
 # Allows the default dictionary to be used.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,20 +21,20 @@ path = "src/lib.rs"
 name = "petname"
 path = "src/main.rs"
 doc = false
-required-features = ["clap", "std_rng", "default_dictionary"]
+required-features = ["structopt", "std_rng", "default_dictionary"]
 
 [features]
 # We include features that must be used for the binary regardless of if they are used (like clap).
-default = ["clap", "std_rng", "default_dictionary"]
+default = ["structopt", "std_rng", "default_dictionary"]
 # Allows generating petnames with thread rng.
 std_rng = ["rand/std", "rand/std_rng"]
 # Allows the default dictionary to be used.
 default_dictionary = []
 
 [dependencies]
-clap = { version = "^2.33.0", default-features = false, optional = true }
 itertools = { version = "^0.10.0", default-features = false }
 rand = { version = "^0.8.0", default-features = false }
+structopt = { version =  "^0.3.23", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 # Limit docs.rs builds to a single tier one target, because they're identical on

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "rust-petname",
+    about = "Generate human readable random names.",
+    author,
+    after_help = "Based on Dustin Kirkland's petname project <https://github.com/dustinkirkland/petname>."
+)]
+pub struct Cli {
+    /// Number of words in name
+    #[structopt(short, long, value_name = "WORDS", default_value = "2")]
+    pub words: u8,
+
+    /// Separator between words
+    #[structopt(short, long, value_name = "SEP", default_value = "-")]
+    pub separator: String,
+
+    /// Use small words (0), medium words (1), or large words (2)
+    #[structopt(short, long, value_name = "COM", possible_values = &["0", "1", "2"], default_value = "0", hide_possible_values = true)]
+    pub complexity: u8,
+
+    /// Directory containing adjectives.txt, adverbs.txt, names.txt
+    #[structopt(short, long = "dir", value_name = "DIR", conflicts_with = "complexity")]
+    pub directory: Option<PathBuf>,
+
+    /// Generate multiple names; pass 0 to produce infinite names
+    /// (--count=0 is deprecated; use --stream instead)
+    #[structopt(long, value_name = "COUNT", default_value = "1")]
+    pub count: usize,
+
+    /// Stream names continuously
+    #[structopt(long, conflicts_with = "count")]
+    pub stream: bool,
+
+    /// Do not generate the same name more than once
+    #[structopt(long)]
+    pub non_repeating: bool,
+
+    /// Maximum number of letters in each word; 0 for unlimited
+    #[structopt(short, long, value_name = "LETTERS", default_value = "0")]
+    pub letters: usize,
+
+    /// Generate names where each word begins with the same letter
+    #[structopt(short, long)]
+    pub alliterate: bool,
+
+    /// Generate names where each word begins with the given letter
+    #[structopt(short = "A", long, value_name = "LETTER")]
+    pub alliterate_with: Option<char>,
+
+    // For compatibility with upstream.
+    /// Alias; see --alliterate
+    #[structopt(short, long)]
+    pub ubuntu: bool,
+}


### PR DESCRIPTION
This eliminates some boilerplate clap code, such as manual parsing of option values.

AFAIK it behaves the same as equivalent clap code.