### PR TITLE
Update arg parsing to clap v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,17 +26,15 @@ required-features = ["clap", "std_rng", "default_dictionary"]
 [features]
 # We include features that must be used for the binary regardless of if they are used (like clap).
 default = ["clap", "std_rng", "default_dictionary"]
-# Alias for backward compatibility.
-clap = ["structopt"]
 # Allows generating petnames with thread rng.
 std_rng = ["rand/std", "rand/std_rng"]
 # Allows the default dictionary to be used.
 default_dictionary = []
 
 [dependencies]
+clap = { version =  "^3.0", features = ["derive"], optional = true }
 itertools = { version = "^0.10.0", default-features = false }
 rand = { version = "^0.8.0", default-features = false }
-structopt = { version =  "^0.3.23", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 # Limit docs.rs builds to a single tier one target, because they're identical on

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,58 +1,58 @@
 use std::path::PathBuf;
 
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(StructOpt)]
-#[structopt(
+/// Generate human readable random names.
+#[derive(Parser)]
+#[clap(
     name = "rust-petname",
-    about = "Generate human readable random names.",
     author,
     after_help = "Based on Dustin Kirkland's petname project <https://github.com/dustinkirkland/petname>."
 )]
 pub struct Cli {
     /// Number of words in name
-    #[structopt(short, long, value_name = "WORDS", default_value = "2")]
+    #[clap(short, long, value_name = "WORDS", default_value_t = 2)]
     pub words: u8,
 
     /// Separator between words
-    #[structopt(short, long, value_name = "SEP", default_value = "-")]
+    #[clap(short, long, value_name = "SEP", default_value = "-")]
     pub separator: String,
 
     /// Use small words (0), medium words (1), or large words (2)
-    #[structopt(short, long, value_name = "COM", possible_values = &["0", "1", "2"], default_value = "0", hide_possible_values = true)]
+    #[clap(short, long, value_name = "COM", possible_values = &["0", "1", "2"], default_value_t = 0, hide_possible_values = true)]
     pub complexity: u8,
 
     /// Directory containing adjectives.txt, adverbs.txt, names.txt
-    #[structopt(short, long = "dir", value_name = "DIR", conflicts_with = "complexity")]
+    #[clap(short, long = "dir", value_name = "DIR", conflicts_with = "complexity")]
     pub directory: Option<PathBuf>,
 
     /// Generate multiple names; pass 0 to produce infinite names
     /// (--count=0 is deprecated; use --stream instead)
-    #[structopt(long, value_name = "COUNT", default_value = "1")]
+    #[clap(long, value_name = "COUNT", default_value_t = 1)]
     pub count: usize,
 
     /// Stream names continuously
-    #[structopt(long, conflicts_with = "count")]
+    #[clap(long, conflicts_with = "count")]
     pub stream: bool,
 
     /// Do not generate the same name more than once
-    #[structopt(long)]
+    #[clap(long)]
     pub non_repeating: bool,
 
     /// Maximum number of letters in each word; 0 for unlimited
-    #[structopt(short, long, value_name = "LETTERS", default_value = "0")]
+    #[clap(short, long, value_name = "LETTERS", default_value_t = 0)]
     pub letters: usize,
 
     /// Generate names where each word begins with the same letter
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub alliterate: bool,
 
     /// Generate names where each word begins with the given letter
-    #[structopt(short = "A", long, value_name = "LETTER")]
+    #[clap(short = 'A', long, value_name = "LETTER")]
     pub alliterate_with: Option<char>,
 
     // For compatibility with upstream.
     /// Alias; see --alliterate
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub ubuntu: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,10 @@ use std::path;
 use std::process;
 
 use rand::seq::IteratorRandom;
-use structopt::StructOpt;
+use clap::Parser;
 
 fn main() {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
     match run(cli) {
         Ok(()) | Err(Error::Disconnected) => {
             process::exit(0);


### PR DESCRIPTION
Clap 3.0.0 (aka the new `structopt`) has been released recently 🥳