### PR TITLE
Bring back the `-V` and `--version` command-line options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ std_rng = ["rand/std", "rand/std_rng"]
 default_dictionary = []
 
 [dependencies]
-clap = {version = "^3.1.0", features = ["derive"], optional = true}
-itertools = {version = "^0.10.3", default-features = false}
-rand = {version = "^0.8.5", default-features = false}
+clap = { version = "^3.1.0", features = ["cargo", "derive"], optional = true }
+itertools = { version = "^0.10.3", default-features = false }
+rand = { version = "^0.8.5", default-features = false }
 
 [package.metadata.docs.rs]
 # Limit docs.rs builds to a single tier one target, because they're identical on

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ should behave the same.
 
 ```shellsession
 $ petname --help
-rust-petname
+rust-petname 1.1.3
 Gavin Panella <gavinpanella@gmail.com>
 Generate human readable random names
 
@@ -67,6 +67,7 @@ OPTIONS:
     -s, --separator <SEP>             Separator between words [default: -]
         --stream                      Stream names continuously
     -u, --ubuntu                      Alias; see --alliterate
+    -V, --version                     Print version information
     -w, --words <WORDS>               Number of words in name [default: 2]
 
 Based on Dustin Kirkland's petname project <https://github.com/dustinkirkland/petname>.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 
+use clap::crate_version;
 use clap::Parser;
 
 /// Generate human readable random names.
 #[derive(Parser)]
 #[clap(
     name = "rust-petname",
+    version = crate_version!(),
     author,
     after_help = "Based on Dustin Kirkland's petname project <https://github.com/dustinkirkland/petname>."
 )]


### PR DESCRIPTION
These were accidentally lost in the upgrade to clap v3. Fixes #83.