### PR TITLE
Allow passing seed as argument

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,7 +58,13 @@ pub struct Cli {
     #[clap(short, long)]
     pub ubuntu: bool,
 
-    /// Seed the rng with this value
-    #[clap(short = 'S', long, value_name = "SEED")]
+    /// Seed the RNG with this value (unsigned 64-bit integer in base-10)
+    ///
+    /// This makes the names chosen deterministic and repeatable: with the same
+    /// seed, the same names will be emitted. Note that which name or names are
+    /// emitted is not guaranteed across versions of rust-petname because the
+    /// underlying random number generator in use explicitly does not make that
+    /// guarantee.
+    #[clap(long, value_name = "SEED")]
     pub seed: Option<u64>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,4 +57,8 @@ pub struct Cli {
     /// Alias; see --alliterate
     #[clap(short, long)]
     pub ubuntu: bool,
+
+    /// Seed the rng with this value
+    #[clap(short = 'S', long, value_name = "SEED")]
+    pub seed: Option<u64>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::path;
 use std::process;
 
 use clap::Parser;
-use rand::seq::IteratorRandom;
+use rand::{seq::IteratorRandom, SeedableRng};
 
 fn main() {
     let cli = Cli::parse();
@@ -82,7 +82,8 @@ fn run(cli: Cli) -> Result<(), Error> {
     }
 
     // We're going to need a source of randomness.
-    let mut rng = rand::thread_rng();
+    let mut rng =
+        cli.seed.map(rand::rngs::StdRng::seed_from_u64).unwrap_or_else(|| rand::rngs::StdRng::from_entropy());
 
     // Handle alliteration, either by eliminating a specified
     // character, or using a random one.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn run(cli: Cli) -> Result<(), Error> {
 
     // We're going to need a source of randomness.
     let mut rng =
-        cli.seed.map(rand::rngs::StdRng::seed_from_u64).unwrap_or_else(|| rand::rngs::StdRng::from_entropy());
+        cli.seed.map(rand::rngs::StdRng::seed_from_u64).unwrap_or_else(rand::rngs::StdRng::from_entropy);
 
     // Handle alliteration, either by eliminating a specified
     // character, or using a random one.


### PR DESCRIPTION
This allows passing the seed as u64.