### PR TITLE
Alliterations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,8 +242,7 @@ impl<'a> Petnames<'a> {
     /// Calculate the cardinality of this `Petnames`.
     ///
     /// If this is low, names may be repeated by the generator with a higher
-    /// frequency than your use-case may allow. If it is 0 (zero) the generator
-    /// will panic (unless `words` is also zero).
+    /// frequency than your use-case may allow.
     ///
     /// This can saturate. If the total possible combinations of words exceeds
     /// `u128::MAX` then this will return `u128::MAX`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,11 @@ pub fn petname(words: u8, separator: &str) -> String {
 /// A word list.
 pub type Words<'a> = Cow<'a, [&'a str]>;
 
+#[cfg(feature = "default-words")]
+mod words {
+    include!(concat!(env!("OUT_DIR"), "/words.rs"));
+}
+
 /// Trait that defines a generator of petnames.
 ///
 /// There are default implementations of `generate_one` and `iter`, i.e. only
@@ -163,11 +168,6 @@ pub struct Petnames<'a> {
     pub adjectives: Words<'a>,
     pub adverbs: Words<'a>,
     pub nouns: Words<'a>,
-}
-
-#[cfg(feature = "default-words")]
-mod words {
-    include!(concat!(env!("OUT_DIR"), "/words.rs"));
 }
 
 impl<'a> Petnames<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
 
 use cli::Cli;
-use petname::Petnames;
+use petname::{Generator, Petnames};
 
 use std::collections::HashSet;
 use std::fmt;

--- a/tests/alliterations.rs
+++ b/tests/alliterations.rs
@@ -1,0 +1,61 @@
+use std::collections::HashSet;
+
+use rand::rngs::mock::StepRng;
+
+use petname::{Alliterations, Generator, Petnames};
+
+#[test]
+fn alliterations_from_petnames() {
+    let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
+    let alliterations: Alliterations = petnames.into();
+    let alliterations_expected = Alliterations {
+        groups: [
+            ('a', Petnames::new("able", "", "ant")),
+            ('b', Petnames::new("bold", "burly", "bee")),
+            ('c', Petnames::new("", "curly", "cow")),
+        ]
+        .into(),
+    };
+    assert_eq!(alliterations_expected, alliterations);
+}
+
+#[test]
+fn alliterations_retain_applies_given_predicate() {
+    let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
+    let mut alliterations: Alliterations = petnames.into();
+    alliterations.retain(|first_letter, _petnames| *first_letter != 'b');
+    let alliterations_expected = Alliterations {
+        groups: [('a', Petnames::new("able", "", "ant")), ('c', Petnames::new("", "curly", "cow"))].into(),
+    };
+    assert_eq!(alliterations_expected, alliterations);
+}
+
+#[test]
+#[cfg(feature = "default-words")]
+fn alliterations_default_has_non_zero_cardinality() {
+    let alliterations = Alliterations::default();
+    // This test will need to be adjusted when word lists change.
+    assert_eq!(0, alliterations.cardinality(0));
+    assert_eq!(456, alliterations.cardinality(1));
+    assert_eq!(11416, alliterations.cardinality(2));
+    assert_eq!(198753, alliterations.cardinality(3));
+    assert_eq!(4262775, alliterations.cardinality(4));
+}
+
+#[test]
+fn alliterations_generate_uses_adverb_adjective_name() {
+    let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
+    let alliterations: Alliterations = petnames.into();
+    assert_eq!(alliterations.generate(&mut StepRng::new(1234567890, 1), 3, "-"), "burly-bold-bee");
+}
+
+#[test]
+fn alliterations_iter_yields_names() {
+    let mut rng = StepRng::new(1234567890, 1234567890);
+    let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
+    let alliterations: Alliterations = petnames.into();
+    let names = alliterations.iter(&mut rng, 3, " ");
+    let expected: HashSet<String> = ["able ant", "burly bold bee", "curly cow"].map(String::from).into();
+    let observed: HashSet<String> = names.take(10).collect::<HashSet<String>>();
+    assert_eq!(expected, observed);
+}

--- a/tests/alliterations.rs
+++ b/tests/alliterations.rs
@@ -46,7 +46,10 @@ fn alliterations_default_has_non_zero_cardinality() {
 fn alliterations_generate_uses_adverb_adjective_name() {
     let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
     let alliterations: Alliterations = petnames.into();
-    assert_eq!(alliterations.generate(&mut StepRng::new(1234567890, 1), 3, "-"), "burly-bold-bee");
+    assert_eq!(
+        alliterations.generate(&mut StepRng::new(1234567890, 1), 3, "-"),
+        Some("burly-bold-bee".into())
+    );
 }
 
 #[test]
@@ -58,4 +61,13 @@ fn alliterations_iter_yields_names() {
     let expected: HashSet<String> = ["able ant", "burly bold bee", "curly cow"].map(String::from).into();
     let observed: HashSet<String> = names.take(10).collect::<HashSet<String>>();
     assert_eq!(expected, observed);
+}
+
+#[test]
+fn alliterations_iter_yields_nothing_when_empty() {
+    let mut rng = StepRng::new(0, 1);
+    let alliteration = Alliterations { groups: Default::default() };
+    assert_eq!(0, alliteration.cardinality(3));
+    let mut names: Box<dyn Iterator<Item = _>> = alliteration.iter(&mut rng, 3, ".");
+    assert_eq!(None, names.next());
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 #[cfg(all(feature = "default-rng", feature = "default-words"))]
 use petname::petname;
-use petname::Petnames;
+use petname::{Generator, Petnames};
 use rand::rngs::mock::StepRng;
 
 #[test]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -7,27 +7,27 @@ use rand::rngs::mock::StepRng;
 
 #[test]
 #[cfg(feature = "default-words")]
-fn default_petnames_has_adjectives() {
+fn petnames_default_has_adjectives() {
     let petnames = Petnames::default();
     assert_ne!(petnames.adjectives.len(), 0);
 }
 
 #[test]
 #[cfg(feature = "default-words")]
-fn default_petnames_has_adverbs() {
+fn petnames_default_has_adverbs() {
     let petnames = Petnames::default();
     assert_ne!(petnames.adverbs.len(), 0);
 }
 
 #[test]
 #[cfg(feature = "default-words")]
-fn default_petnames_has_names() {
+fn petnames_default_has_names() {
     let petnames = Petnames::default();
     assert_ne!(petnames.nouns.len(), 0);
 }
 
 #[test]
-fn retain_applies_given_predicate() {
+fn petnames_retain_applies_given_predicate() {
     let petnames_expected = Petnames::new("bob", "bob", "bob jane");
     let mut petnames = Petnames::new("alice bob carol", "alice bob", "bob carol jane");
     petnames.retain(|word| word.len() < 5);
@@ -36,7 +36,7 @@ fn retain_applies_given_predicate() {
 
 #[test]
 #[cfg(feature = "default-words")]
-fn default_petnames_has_non_zero_cardinality() {
+fn petnames_default_has_non_zero_cardinality() {
     let petnames = Petnames::default();
     // This test will need to be adjusted when word lists change.
     assert_eq!(0, petnames.cardinality(0));
@@ -47,13 +47,23 @@ fn default_petnames_has_non_zero_cardinality() {
 }
 
 #[test]
-fn generate_uses_adverb_adjective_name() {
+fn petnames_generate_uses_adverb_adjective_name() {
     let petnames = Petnames {
         adjectives: Cow::Owned(vec!["adjective"]),
         adverbs: Cow::Owned(vec!["adverb"]),
         nouns: Cow::Owned(vec!["noun"]),
     };
     assert_eq!(petnames.generate(&mut StepRng::new(0, 1), 3, "-"), "adverb-adjective-noun");
+}
+
+#[test]
+fn petnames_iter_yields_names() {
+    let mut rng = StepRng::new(0, 1);
+    let petnames = Petnames::new("foo", "bar", "baz");
+    let names = petnames.iter(&mut rng, 3, ".");
+    // Definitely an Iterator...
+    let mut iter: Box<dyn Iterator<Item = _>> = Box::new(names);
+    assert_eq!(Some("bar.foo.baz".to_string()), iter.next());
 }
 
 #[test]
@@ -66,14 +76,4 @@ fn petname_renders_desired_number_of_words() {
 #[cfg(all(feature = "default-rng", feature = "default-words"))]
 fn petname_renders_with_desired_separator() {
     assert_eq!(petname(7, "@").split('@').count(), 7);
-}
-
-#[test]
-fn petnames_iter_yields_names() {
-    let mut rng = StepRng::new(0, 1);
-    let petnames = Petnames::new("foo", "bar", "baz");
-    let names = petnames.iter(&mut rng, 3, ".");
-    // Definitely an Iterator...
-    let mut iter: Box<dyn Iterator<Item = _>> = Box::new(names);
-    assert_eq!(Some("bar.foo.baz".to_string()), iter.next());
 }

--- a/tests/petname.rs
+++ b/tests/petname.rs
@@ -1,0 +1,14 @@
+#[cfg(all(feature = "default-rng", feature = "default-words"))]
+use petname::petname;
+
+#[test]
+#[cfg(all(feature = "default-rng", feature = "default-words"))]
+fn petname_renders_desired_number_of_words() {
+    assert_eq!(petname(7, "-").split('-').count(), 7);
+}
+
+#[test]
+#[cfg(all(feature = "default-rng", feature = "default-words"))]
+fn petname_renders_with_desired_separator() {
+    assert_eq!(petname(7, "@").split('@').count(), 7);
+}

--- a/tests/petname.rs
+++ b/tests/petname.rs
@@ -4,11 +4,11 @@ use petname::petname;
 #[test]
 #[cfg(all(feature = "default-rng", feature = "default-words"))]
 fn petname_renders_desired_number_of_words() {
-    assert_eq!(petname(7, "-").split('-').count(), 7);
+    assert_eq!(petname(7, "-").unwrap().split('-').count(), 7);
 }
 
 #[test]
 #[cfg(all(feature = "default-rng", feature = "default-words"))]
 fn petname_renders_with_desired_separator() {
-    assert_eq!(petname(7, "@").split('@').count(), 7);
+    assert_eq!(petname(7, "@").unwrap().split('@').count(), 7);
 }

--- a/tests/petnames.rs
+++ b/tests/petnames.rs
@@ -49,7 +49,7 @@ fn petnames_generate_uses_adverb_adjective_name() {
         adverbs: vec!["adverb"].into(),
         nouns: vec!["noun"].into(),
     };
-    assert_eq!(petnames.generate(&mut StepRng::new(0, 1), 3, "-"), "adverb-adjective-noun");
+    assert_eq!(petnames.generate(&mut StepRng::new(0, 1), 3, "-"), Some("adverb-adjective-noun".into()));
 }
 
 #[test]
@@ -58,4 +58,13 @@ fn petnames_iter_yields_names() {
     let petnames = Petnames::new("foo", "bar", "baz");
     let mut names: Box<dyn Iterator<Item = _>> = petnames.iter(&mut rng, 3, ".");
     assert_eq!(Some("bar.foo.baz".to_string()), names.next());
+}
+
+#[test]
+fn petnames_iter_yields_nothing_when_empty() {
+    let mut rng = StepRng::new(0, 1);
+    let petnames = Petnames::new("", "", "");
+    assert_eq!(0, petnames.cardinality(3));
+    let mut names: Box<dyn Iterator<Item = _>> = petnames.iter(&mut rng, 3, ".");
+    assert_eq!(None, names.next());
 }

--- a/tests/petnames.rs
+++ b/tests/petnames.rs
@@ -1,7 +1,3 @@
-use std::borrow::Cow;
-
-#[cfg(all(feature = "default-rng", feature = "default-words"))]
-use petname::petname;
 use petname::{Generator, Petnames};
 use rand::rngs::mock::StepRng;
 
@@ -49,9 +45,9 @@ fn petnames_default_has_non_zero_cardinality() {
 #[test]
 fn petnames_generate_uses_adverb_adjective_name() {
     let petnames = Petnames {
-        adjectives: Cow::Owned(vec!["adjective"]),
-        adverbs: Cow::Owned(vec!["adverb"]),
-        nouns: Cow::Owned(vec!["noun"]),
+        adjectives: vec!["adjective"].into(),
+        adverbs: vec!["adverb"].into(),
+        nouns: vec!["noun"].into(),
     };
     assert_eq!(petnames.generate(&mut StepRng::new(0, 1), 3, "-"), "adverb-adjective-noun");
 }
@@ -60,20 +56,6 @@ fn petnames_generate_uses_adverb_adjective_name() {
 fn petnames_iter_yields_names() {
     let mut rng = StepRng::new(0, 1);
     let petnames = Petnames::new("foo", "bar", "baz");
-    let names = petnames.iter(&mut rng, 3, ".");
-    // Definitely an Iterator...
-    let mut iter: Box<dyn Iterator<Item = _>> = Box::new(names);
-    assert_eq!(Some("bar.foo.baz".to_string()), iter.next());
-}
-
-#[test]
-#[cfg(all(feature = "default-rng", feature = "default-words"))]
-fn petname_renders_desired_number_of_words() {
-    assert_eq!(petname(7, "-").split('-').count(), 7);
-}
-
-#[test]
-#[cfg(all(feature = "default-rng", feature = "default-words"))]
-fn petname_renders_with_desired_separator() {
-    assert_eq!(petname(7, "@").split('@').count(), 7);
+    let mut names: Box<dyn Iterator<Item = _>> = petnames.iter(&mut rng, 3, ".");
+    assert_eq!(Some("bar.foo.baz".to_string()), names.next());
 }


### PR DESCRIPTION
This extracts a `Generator` trait out of `Petnames`, then introduces a new `Alliterations` type that implements it too. It's possible to create an `Alliterations` directly from a `Petnames` and then use it to generate names just the same, except that all words in generated names will start with the same letter. The difference to before is that now, when generating multiple names, each name does not need to start with the same letter as the previous name.

Fixes #60.