### PR TITLE
Be doubly sure that `writer` is flushed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "Clippy",
         "dtolnay",
+        "impls",
         "itertools",
         "pbcopy",
         "petname",


### PR DESCRIPTION
An embarrassing bug made it into 2.0.0 🤦 Using the command-line tool, often you'd see nothing printed because the process was exiting (by an explicit call to `std::process::exit`) before the output buffer was able to flush itself. Now, the output stream is explicitly flushed _and_ the output stream and buffer are allowed to drop as normal before `exit` is called.