### PR TITLE
Update word lists from upstream petname v2.9 release

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,6 @@ mod integration {
     #[test]
     fn option_seed() {
         let cli = super::Cli::parse_from(["petname", "--seed=12345", "--words=3"]);
-        assert_eq!(run_and_capture(cli), "meaningfully-enthralled-termite\n");
+        assert_eq!(run_and_capture(cli), "meaningfully-enthralled-pinscher\n");
     }
 }

--- a/tests/alliterations.rs
+++ b/tests/alliterations.rs
@@ -33,10 +33,10 @@ fn alliterations_default_has_non_zero_cardinality() {
     let alliterations = Alliterations::default();
     // This test will need to be adjusted when word lists change.
     assert_eq!(0, alliterations.cardinality(0));
-    assert_eq!(1060, alliterations.cardinality(1));
-    assert_eq!(69988, alliterations.cardinality(2));
-    assert_eq!(8181574, alliterations.cardinality(3));
-    assert_eq!(1143505062, alliterations.cardinality(4));
+    assert_eq!(1056, alliterations.cardinality(1));
+    assert_eq!(69734, alliterations.cardinality(2));
+    assert_eq!(8145549, alliterations.cardinality(3));
+    assert_eq!(1137581773, alliterations.cardinality(4));
 }
 
 #[test]

--- a/tests/petnames.rs
+++ b/tests/petnames.rs
@@ -36,10 +36,10 @@ fn petnames_default_has_non_zero_cardinality() {
     let petnames = Petnames::default();
     // This test will need to be adjusted when word lists change.
     assert_eq!(0, petnames.cardinality(0));
-    assert_eq!(1060, petnames.cardinality(1));
-    assert_eq!(1269880, petnames.cardinality(2));
-    assert_eq!(2069904400, petnames.cardinality(3));
-    assert_eq!(3373944172000, petnames.cardinality(4));
+    assert_eq!(1056, petnames.cardinality(1));
+    assert_eq!(1265088, petnames.cardinality(2));
+    assert_eq!(2062093440, petnames.cardinality(3));
+    assert_eq!(3361212307200, petnames.cardinality(4));
 }
 
 #[test]

--- a/words/medium/nouns.txt
+++ b/words/medium/nouns.txt
@@ -247,7 +247,6 @@ doe
 dog
 dogfish
 dolphin
-donkey
 dormouse
 dory
 dotterel
@@ -442,7 +441,6 @@ insect
 jabiru
 jacamar
 jackal
-jackass
 jackdaw
 jackrabbit
 jaeger
@@ -911,7 +909,6 @@ swan
 sweeper
 swift
 swiftlet
-swine
 swordfish
 swordtail
 sylph
@@ -934,7 +931,6 @@ teal
 tench
 tenpounder
 tenrec
-termite
 tern
 terrapin
 terrier

--- a/words/small/nouns.txt
+++ b/words/small/nouns.txt
@@ -177,7 +177,6 @@ snipe
 squid
 stork
 swift
-swine
 tapir
 tetra
 tiger
@@ -204,7 +203,6 @@ condor
 cougar
 coyote
 dassie
-donkey
 dragon
 earwig
 falcon
@@ -311,7 +309,6 @@ hagfish
 halibut
 hamster
 herring
-jackass
 javelin
 jawfish
 jaybird
@@ -368,7 +365,6 @@ sunbeam
 sunbird
 sunfish
 tadpole
-termite
 terrier
 unicorn
 vulture


### PR DESCRIPTION
[dustinkirkland/petname v2.9](https://github.com/dustinkirkland/petname/releases/tag/2.9) was released with some small changes to word lists.