### PR TITLE
Update rand dependency to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "petname"
 readme = "README.md"
 repository = "https://github.com/allenap/rust-petname"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 
 [lib]
 name = "petname"
@@ -26,7 +26,7 @@ required-features = ["clap", "default-rng", "default-words"]
 # _every time_ you want to build the binary, so it's here as a convenience.
 default = ["clap", "default-rng", "default-words"]
 # Allows generating petnames with thread rng.
-default-rng = ["rand/std", "rand/std_rng"]
+default-rng = ["rand/thread_rng"]
 # Allows the default word lists to be used.
 default-words = []
 
@@ -42,7 +42,7 @@ quote = "1"
 [dependencies]
 clap = { version = "4.4", features = ["cargo", "derive"], optional = true }
 itertools = { version = ">=0.11", default-features = false }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.9", default-features = false }
 
 [package.metadata.docs.rs]
 # Limit docs.rs builds to a single tier one target, because they're identical on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ use alloc::{
     vec::Vec,
 };
 
-use rand::seq::{IteratorRandom, SliceRandom};
+use rand::seq::{IndexedRandom, IteratorRandom};
 
 /// Convenience function to generate a new petname from default word lists.
 #[allow(dead_code)]
@@ -153,7 +153,7 @@ pub trait Generator<'a> {
     /// when you want to use a custom source of randomness.
     #[cfg(feature = "default-rng")]
     fn generate_one(&self, words: u8, separator: &str) -> Option<String> {
-        self.generate(&mut rand::thread_rng(), words, separator)
+        self.generate(&mut rand::rng(), words, separator)
     }
 
     /// Generate a new petname and return the constituent words.

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ where
 
     // We're going to need a source of randomness.
     let mut rng =
-        cli.seed.map(rand::rngs::StdRng::seed_from_u64).unwrap_or_else(rand::rngs::StdRng::from_entropy);
+        cli.seed.map(rand::rngs::StdRng::seed_from_u64).unwrap_or_else(rand::rngs::StdRng::from_os_rng);
 
     // Stream, or print a limited number of words?
     let count = if cli.stream { None } else { Some(cli.count) };
@@ -311,6 +311,6 @@ mod integration {
     #[test]
     fn option_seed() {
         let cli = super::Cli::parse_from(["petname", "--seed=12345", "--words=3"]);
-        assert_eq!(run_and_capture(cli), "meaningfully-enthralled-pinscher\n");
+        assert_eq!(run_and_capture(cli), "meaningfully-enthralled-vendace\n");
     }
 }

--- a/tests/alliterations.rs
+++ b/tests/alliterations.rs
@@ -44,7 +44,7 @@ fn alliterations_generate_uses_adverb_adjective_name() {
     let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
     let alliterations: Alliterations = petnames.into();
     assert_eq!(
-        alliterations.generate(&mut StepRng::new(1234567890, 1), 3, "-"),
+        alliterations.generate(&mut StepRng::new(6234567891, 1), 3, "-"),
         Some("burly-bold-bee".into())
     );
 }


### PR DESCRIPTION
https://github.com/rust-random/rand/releases/tag/0.9.0

As you can see from the patch, this changes the CLI output when using a seed. Most likely due to https://github.com/rust-random/rand/pull/1268 or one of the other optimizations mentioned in the changelog.

This update is not super important for me, but it would certainly come in handy if a library consumer must use rand 0.9 for some other reason.