### PR TITLE
Introduce `Namer`; redesign `Generator` for performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
-      - run: cargo test --no-default-features
+      - run: cargo install cargo-hack
+      - run: cargo hack --workspace --feature-powerset build
+      - run: cargo hack --workspace --feature-powerset test
 
   fmt:
     name: Rustfmt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "petname",
         "Petnames",
         "pname",
+        "powerset",
         "rngs",
         "rustfmt",
         "rustup",

--- a/README.md
+++ b/README.md
@@ -196,8 +196,17 @@ largely unchanged.
 - The `rand` dependency has been bumped from 0.9 to 0.10. If you depend on
   `rand` types (e.g. `RngCore`, `SmallRng`) directly in your own code, you will
   need to upgrade your `rand` dependency to match.
-- The `Generator` trait has changed. The `generate` and `generate_one` methods
-  are gone. The one required method now is `generate_into`.
+- The `Generator` trait has changed significantly:
+  - The `generate` and `generate_one` methods are gone.
+  - The trait no longer has a lifetime parameter; `Generator<'a>` is now just
+    `Generator`.
+  - The one required method is `generate_into`.
+  - The `iter` method has been renamed to `namer`. It now returns a [`Namer`]
+    directly instead of `Box<dyn Iterator<Item = String>>`, so there is no heap
+    allocation for the iterator itself.
+- [`Namer`] is a new public type (an iterator over generated petnames). It is
+  generic over the generator type, so `Namer<Petnames>` and
+  `Namer<Alliterations>` are both valid.
 - The built-in word lists are now compiled into the library via the `petnames!`
   proc macro rather than via `build.rs`. This is mostly an internal change, but
   it does mean that the `petname-macros` crate is a new compile-time dependency

--- a/README.md
+++ b/README.md
@@ -196,11 +196,8 @@ largely unchanged.
 - The `rand` dependency has been bumped from 0.9 to 0.10. If you depend on
   `rand` types (e.g. `RngCore`, `SmallRng`) directly in your own code, you will
   need to upgrade your `rand` dependency to match.
-- The `Generator` trait has a new required method, `generate_raw`. If you have a
-  custom implementation of `Generator`, you must implement `generate_raw` (which
-  returns `Option<Vec<&'a str>>`). The `generate` method now has a default
-  implementation built on top of `generate_raw`, so you may be able to remove
-  your existing `generate` implementation.
+- The `Generator` trait has changed. The `generate` and `generate_one` methods
+  are gone. The one required method now is `generate_parts`.
 - The built-in word lists are now compiled into the library via the `petnames!`
   proc macro rather than via `build.rs`. This is mostly an internal change, but
   it does mean that the `petname-macros` crate is a new compile-time dependency

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ largely unchanged.
   `rand` types (e.g. `RngCore`, `SmallRng`) directly in your own code, you will
   need to upgrade your `rand` dependency to match.
 - The `Generator` trait has changed. The `generate` and `generate_one` methods
-  are gone. The one required method now is `generate_parts`.
+  are gone. The one required method now is `generate_into`.
 - The built-in word lists are now compiled into the library via the `petnames!`
   proc macro rather than via `build.rs`. This is mostly an internal change, but
   it does mean that the `petname-macros` crate is a new compile-time dependency

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ user    0m0.032s
 sys     0m0.008s
 
 $ time target/release/petname
-cool-guinea
+contiguous-seriema
 
-real    0m0.002s
-user    0m0.002s
-sys     0m0.000s
+real    0m0.004s
+user    0m0.001s
+sys     0m0.002s
 ```
 
 These timings are irrelevant if you only need to name a single thing, but if you
@@ -118,9 +118,9 @@ sys     0m5.163s
 
 $ time { for i in $(seq 1000); do target/release/petname; done; } > /dev/null
 
-real    0m2.199s
-user    0m1.333s
-sys     0m0.987s
+real    0m2.293s
+user    0m1.044s
+sys     0m1.003s
 ```
 
 To be fair, `/usr/bin/petname` is a shell script. The Go command-line version
@@ -134,12 +134,12 @@ considerably:
 ```shellsession
 $ time target/release/petname --count=10000000 > /dev/null
 
-real    0m1.327s
-user    0m1.322s
-sys     0m0.004s
+real    0m0.785s
+user    0m0.767s
+sys     0m0.016s
 ```
 
-That's ~240,000 (two hundred and forty thousand) times faster, for about 7.5
+That's ~408,000 (four hundred and eight thousand) times faster, for about 12.7
 million petnames a second on this hardware. This is useful if you want to apply
 an external filter to the names being generated:
 

--- a/README.md
+++ b/README.md
@@ -276,14 +276,17 @@ After installing the source (see above) run tests with: `cargo test`.
    the top). On macOS the command `cargo run -- -h | pbcopy` is helpful.
    **Note** that `--help` output is not the same as `-h` output: it's more
    verbose and too much for an overview.
-1. Build **and** test. The latter on its own does do a build, but a test build
-   can hide warnings about dead code, so do both.
-   - With default features: `cargo build && cargo test`
-   - Without: `cargo build --no-default-features && cargo test --no-default-features`
+1. Build **and** test all crates in the workspace. Testing on its own does build
+   code, but a test build can hide warnings about dead code, so do both. To test
+   feature combinations, install [cargo-hack][] first, then:
+   - `cargo hack --workspace --feature-powerset build`
+   - `cargo hack --workspace --feature-powerset test`
 1. Commit with message "Bump version to `$VERSION`."
 1. Tag with "v`$VERSION`", e.g. `git tag v1.0.10`.
 1. Push: `git push && git push --tags`.
 1. Publish: `cargo publish`.
+
+[cargo-hack]: https://crates.io/crates/cargo-hack
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,15 @@
 #![no_std]
 //!
-//! You can populate [`Petnames`] with your own word lists, but the word lists
-//! from upstream [petname](https://github.com/dustinkirkland/petname) are
-//! included with the `default-words` feature (enabled by default). See
-//! [`Petnames::small`], [`Petnames::medium`], and [`Petnames::large`] to select
-//! a particular built-in word list, or use [`Petnames::default`].
+//! [`petname()`] will generate a single name with a default random number
+//! generator:
 //!
-//! For more flexibility, see the [`petnames!`] macro, with which you can
-//! statically embed your own word lists at compile-time. This is available with
-//! the `macros` feature (enabled by default). The same mechanism is used to
-//! embed the default word lists.
+//! ```rust
+//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+//! let name: Option<String> = petname::petname(3, "-");
+//! // e.g. deftly-apt-swiftlet
+//! ```
 //!
-//! To generate a petname, the other thing you need is a random number generator
-//! from [rand][]:
+//! You can bring your own random number generator from [rand][]:
 //!
 //! ```rust
 //! use petname::Generator; // Trait needs to be in scope for `iter`.
@@ -24,19 +21,12 @@
 //! # } }
 //! ```
 //!
-//! There's a [convenience function][petname()] that'll generate a single name
-//! with a default random number generator:
+//! See that call to [`iter`][`Petnames::iter`] above? It returned a standard
+//! [`Iterator`]. This is more efficient than calling [`petname()`] repeatedly,
+//! plus you get all the features of Rust iterators:
 //!
 //! ```rust
-//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-//! let name = petname::petname(7, ":");
-//! ```
-//!
-//! A more flexible approach is to create an [`Iterator`] with
-//! [`iter`][`Petnames::iter`]:
-//!
-//! ```rust
-//! use petname::Generator; // Trait needs to be in scope for `iter`.
+//! # use petname::Generator; // Trait needs to be in scope for `iter`.
 //! # #[cfg(feature = "default-rng")]
 //! let mut rng = rand::rngs::ThreadRng::default();
 //! # #[cfg(feature = "default-words")]
@@ -45,6 +35,27 @@
 //! let ten_thousand_names: Vec<String> =
 //!   petnames.iter(&mut rng, 3, "_").take(10000).collect();
 //! ```
+//!
+//! 💡 Even more efficient but slightly less convenient is
+//! [`Generator::generate_into`].
+//!
+//! # Word lists
+//!
+//! You can populate [`Petnames`] with your own word lists at runtime, but the
+//! word lists from upstream [petname][] are included with the `default-words`
+//! feature (which is enabled by default). See [`Petnames::small`],
+//! [`Petnames::medium`], and [`Petnames::large`] to select a particular
+//! built-in word list, or use [`Petnames::default`].
+//!
+//! ## Embedding your own word lists
+//!
+//! The [`petnames!`] macro will statically embed your own word lists at
+//! compile-time. This is available with the `macros` feature (enabled by
+//! default). This same mechanism is used to embed the default word lists.
+//!
+//! [petname]: https://github.com/dustinkirkland/petname
+//!
+//! ## Basic filtering
 //!
 //! You can modify the word lists to, for example, only use words beginning with
 //! the letter "b":
@@ -60,10 +71,12 @@
 //! # } }
 //! ```
 //!
-//! There's another way to generate alliterative petnames which is useful when
-//! you don't need or want each name to be limited to using the same initial
-//! letter as the previous generated name. Create the `Petnames` as before, and
-//! then convert it into an [`Alliterations`]:
+//! ## Alliterating
+//!
+//! There is another way to generate alliterative petnames, useful in particular
+//! when you don't need or want each name to be limited to using the same
+//! initial letter as the previous generated name. Create the `Petnames` as
+//! before, and then convert it into an [`Alliterations`]:
 //!
 //! ```rust
 //! # use petname::Generator;
@@ -74,6 +87,8 @@
 //! alliterations.iter(&mut rand::rng(), 3, "/").next().expect("no names");
 //! # }
 //! ```
+//!
+//! # The [`Generator`] trait
 //!
 //! Both [`Petnames`] and [`Alliterations`] implement [`Generator`]; this needs
 //! to be in scope in order to generate names. It's [object-safe] so you can use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,32 +12,31 @@
 //! You can bring your own random number generator from [rand][]:
 //!
 //! ```rust
-//! use petname::Generator; // Trait needs to be in scope for `iter`.
 //! # #[cfg(feature = "default-rng")] {
 //! let mut rng = rand::rngs::ThreadRng::default();
 //! # #[cfg(feature = "default-words")] {
 //! let petnames = petname::Petnames::default();
-//! let name = petnames.iter(&mut rng, 7, ":").next().expect("no names");
+//! let name = petnames.namer(7, ":").iter(&mut rng).next().expect("no names");
 //! # } }
 //! ```
 //!
-//! See that call to [`iter`][`Petnames::iter`] above? It returned a standard
+//! See that call to [`namer`][`Petnames::namer`] above? It returned a
+//! [`Namer`]. Calling [`iter`][`Namer::iter`] on that gives a standard
 //! [`Iterator`]. This is more efficient than calling [`petname()`] repeatedly,
 //! plus you get all the features of Rust iterators:
 //!
 //! ```rust
-//! # use petname::Generator; // Trait needs to be in scope for `iter`.
 //! # #[cfg(feature = "default-rng")]
 //! let mut rng = rand::rngs::ThreadRng::default();
 //! # #[cfg(feature = "default-words")]
 //! let petnames = petname::Petnames::default();
 //! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
 //! let ten_thousand_names: Vec<String> =
-//!   petnames.iter(&mut rng, 3, "_").take(10000).collect();
+//!   petnames.namer(3, "_").iter(&mut rng).take(10000).collect();
 //! ```
 //!
 //! 💡 Even more efficient but slightly less convenient is
-//! [`Generator::generate_into`].
+//! [`Namer::generate_into`].
 //!
 //! # Word lists
 //!
@@ -61,12 +60,11 @@
 //! the letter "b":
 //!
 //! ```rust
-//! # use petname::Generator;
 //! # #[cfg(feature = "default-words")] {
 //! let mut petnames = petname::Petnames::default();
 //! petnames.retain(|s| s.starts_with("b"));
 //! # #[cfg(feature = "default-rng")] {
-//! let name = petnames.iter(&mut rand::rng(), 3, ".").next().expect("no names");
+//! let name = petnames.namer(3, ".").iter(&mut rand::rng()).next().expect("no names");
 //! assert!(name.starts_with('b'));
 //! # } }
 //! ```
@@ -79,23 +77,32 @@
 //! before, and then convert it into an [`Alliterations`]:
 //!
 //! ```rust
-//! # use petname::Generator;
 //! # #[cfg(feature = "default-words")] {
 //! let mut petnames = petname::Petnames::default();
 //! let mut alliterations: petname::Alliterations = petnames.into();
 //! # #[cfg(feature = "default-rng")]
-//! alliterations.iter(&mut rand::rng(), 3, "/").next().expect("no names");
+//! alliterations.namer(3, "/").iter(&mut rand::rng()).next().expect("no names");
 //! # }
 //! ```
 //!
 //! # The [`Generator`] trait
 //!
-//! Both [`Petnames`] and [`Alliterations`] implement [`Generator`]; this needs
-//! to be in scope in order to generate names. There are some caveats around its
-//! [object-safety][], so read the trait docs if that affects you.
+//! Both [`Petnames`] and [`Alliterations`] implement [`Generator`]. It's
+//! [object-safe] so you can use them as trait objects:
 //!
-//! [object-safety]:
+//! [object-safe]:
 //!     https://doc.rust-lang.org/reference/items/traits.html#object-safety
+//!
+//! ```rust
+//! use petname::Generator;
+//! let mut buf = String::new();
+//! # #[cfg(all(feature = "default-words", feature = "default-rng"))] {
+//! let petnames: &dyn Generator = &petname::Petnames::default();
+//! petnames.generate_into(&mut buf, &mut rand::rng(), 3, "/");
+//! let alliterations: &dyn Generator = &petname::Alliterations::default();
+//! alliterations.generate_into(&mut buf, &mut rand::rng(), 3, "/");
+//! # }
+//! ```
 //!
 
 extern crate alloc;
@@ -103,7 +110,7 @@ extern crate alloc;
 #[cfg(feature = "macros")]
 extern crate self as petname;
 
-use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, string::String, vec::Vec};
+use alloc::{borrow::Cow, collections::BTreeMap, string::String, vec::Vec};
 
 use rand::seq::{IndexedRandom, IteratorRandom};
 
@@ -111,7 +118,7 @@ use rand::seq::{IndexedRandom, IteratorRandom};
 #[allow(dead_code)]
 #[cfg(all(feature = "default-rng", feature = "default-words"))]
 pub fn petname(words: u8, separator: &str) -> Option<String> {
-    Petnames::default().iter(&mut rand::rng(), words, separator).next()
+    Petnames::default().namer(words, separator).iter(&mut rand::rng()).next()
 }
 
 /// A word list.
@@ -121,51 +128,60 @@ pub type Words<'a> = Cow<'a, [&'a str]>;
 #[cfg(feature = "macros")]
 pub use petname_macros::petnames;
 
-/// Trait that defines a generator of petnames.
+/// Trait that defines a generator of petnames, as consumed by [`Namer`].
 ///
-/// There is a default implementation of [`iter`][`Self::iter`]; only
-/// [`generate_into`][`Self::generate_into`] needs to be implemented.
+/// The sole required method is [`generate_into`][`Self::generate_into`].
 ///
-/// This is _somewhat_ [object-safe] so you can use [`Petnames`] and
-/// [`Alliterations`] as trait objects. The _somewhat_ is because only
-/// [`generate_into`][`Self::generate_into`] will be usable; trying to call
-/// [`iter`][`Self::iter`] on a trait object will not compile.
+/// This trait is [object-safe] so you can use implementors as trait objects.
 ///
 /// [object-safe]:
 ///     https://doc.rust-lang.org/reference/items/traits.html#object-safety
 ///
-/// Here, `generate_into` is fine:
+pub trait Generator {
+    /// Generate a petname into a given [`String`] buffer.
+    ///
+    /// This method does not clear the buffer. The generated name is pushed at
+    /// the end of the string. The name _may_ contain fewer words than requested
+    /// if one or more of the word lists are empty.
+    ///
+    fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str);
+}
+
+/// A configured petname generator.
+///
+/// Created by [`Petnames::namer`] or [`Alliterations::namer`]. Holds a
+/// reference to a word list, a word count, and a separator. Call
+/// [`iter`][`Self::iter`] to get an [`Iterator`] over generated names, or
+/// [`generate_into`][`Self::generate_into`] to write into a buffer directly.
+///
+/// # Examples
 ///
 /// ```rust
-/// use petname::Generator;
+/// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
+/// let petnames = petname::Petnames::default();
+/// let namer = petnames.namer(3, "-");
+///
+/// // As an iterator:
+/// let names: Vec<String> = namer.iter(&mut rand::rng()).take(10).collect();
+///
+/// // Or writing into a buffer:
 /// let mut buf = String::new();
-/// # #[cfg(all(feature = "default-words", feature = "default-rng"))] {
-/// let petnames: &dyn Generator = &petname::Petnames::default();
-/// petnames.generate_into(&mut buf, &mut rand::rng(), 3, "/");
-/// let alliterations: &dyn Generator = &petname::Alliterations::default();
-/// alliterations.generate_into(&mut buf, &mut rand::rng(), 3, "/");
+/// namer.generate_into(&mut buf, &mut rand::rng());
 /// # }
 /// ```
 ///
-/// But `iter` does **not work**:
-///
-/// ```compile_fail
-/// use petname::Generator;
-/// let mut buf = String::new();
-/// # #[cfg(all(feature = "default-words", feature = "default-rng"))] {
-/// let petnames: &dyn Generator = &petname::Petnames::default();
-/// petnames.iter(&mut rand::rng(), 3, "/").next().expect("no names");
-/// let alliterations: &dyn Generator = &petname::Alliterations::default();
-/// alliterations.iter(&mut rand::rng(), 3, "/").next().expect("no names");
-/// # }
-/// ```
-///
-pub trait Generator<'a> {
+pub struct Namer<'a, G: ?Sized> {
+    generator: &'a G,
+    words: u8,
+    separator: &'a str,
+}
+
+impl<'a, G: Generator + ?Sized> Namer<'a, G> {
     /// Generate a petname into a given [`String`] buffer.
     ///
     /// This can be more efficient than [`iter`][`Self::iter`] when generating
-    /// many names because the buffer can be reused; `iter` creates a new
-    /// `String` on every iteration.
+    /// many names because the buffer can be reused; each name yielded by
+    /// [`iter`][`Self::iter`] allocates a new `String`.
     ///
     /// This method does not clear the buffer. The generated name is pushed at
     /// the end of the string.
@@ -173,11 +189,11 @@ pub trait Generator<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # use petname::Generator;
-    /// let mut buf = String::new();
     /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
-    /// let mut rng = rand::rngs::ThreadRng::default();
-    /// petname::Petnames::default().generate_into(&mut buf, &mut rng, 7, "::");
+    /// let petnames = petname::Petnames::default();
+    /// let namer = petnames.namer(7, "::");
+    /// let mut buf = String::new();
+    /// namer.generate_into(&mut buf, &mut rand::rng());
     /// assert_eq!(7, buf.split("::").count());
     /// # }
     /// ```
@@ -187,12 +203,12 @@ pub trait Generator<'a> {
     /// randomness has been exhausted.
     ///
     /// ```rust
-    /// # use petname::Generator;
-    /// let mut buf = String::new();
     /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
     /// let petnames = petname::Petnames::default();
+    /// let namer = petnames.namer(3, "+");
+    /// let mut buf = String::new();
     /// loop {
-    ///     petnames.generate_into(&mut buf, &mut rand::rng(), 3, "+");
+    ///     namer.generate_into(&mut buf, &mut rand::rng());
     ///     if buf.is_empty() {
     ///         break;  // Source exhausted?
     ///     } else {
@@ -204,44 +220,31 @@ pub trait Generator<'a> {
     /// # }
     /// ```
     ///
-    /// # Notes
-    ///
-    /// This constructed name _may_ return fewer words than you request if one
-    /// or more of the word lists are empty. For example, if there are no
-    /// adverbs, requesting 3 or more words may still yield only `["doubtful",
-    /// "salmon"]`.
-    ///
-    fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str);
+    pub fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng) {
+        self.generator.generate_into(buf, rng, self.words, self.separator);
+    }
 
     /// Iterator yielding petnames.
     ///
     /// Note that a new [`String`] is allocated for each name yielded. If this
     /// is a problem, consider [`generate_into`][`Self::generate_into`] instead.
     ///
-    /// See also the notes on [`generate_into`][`Self::generate_into`].
-    ///
     /// # Examples
     ///
     /// ```rust
-    /// # use petname::Generator;
     /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
-    /// let mut rng = rand::rngs::ThreadRng::default();
     /// let petnames = petname::Petnames::default();
-    /// let mut iter = petnames.iter(&mut rng, 4, "_");
-    /// println!("name: {}", iter.next().unwrap());
+    /// let mut rng = rand::rngs::ThreadRng::default();
+    /// let mut namer = petnames.namer(4, "_");
+    /// println!("name: {}", namer.iter(&mut rng).next().unwrap());
     /// # }
     /// ```
-    fn iter(
-        &'a self,
-        rng: &'a mut dyn rand::Rng,
-        words: u8,
-        separator: &'a str,
-    ) -> Box<dyn Iterator<Item = String> + 'a>
-    where
-        Self: Sized,
-    {
-        let names = Names { generator: self, rng, words, separator };
-        Box::new(names)
+    pub fn iter<'b>(&'b self, rng: &'b mut dyn rand::Rng) -> impl Iterator<Item = String> + 'b {
+        core::iter::from_fn(move || {
+            let mut buf = String::new();
+            self.generate_into(&mut buf, rng);
+            (!buf.is_empty()).then_some(buf)
+        })
     }
 }
 
@@ -295,12 +298,11 @@ impl<'a> Petnames<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # use petname::Generator;
     /// # #[cfg(feature = "default-words")] {
     /// let mut petnames = petname::Petnames::default();
     /// petnames.retain(|s| s.starts_with("h"));
     /// # #[cfg(feature = "default-rng")]
-    /// assert!(petnames.iter(&mut rand::rng(), 2, ".").next().unwrap().starts_with('h'));
+    /// assert!(petnames.namer(2, ".").iter(&mut rand::rng()).next().unwrap().starts_with('h'));
     /// # }
     /// ```
     ///
@@ -333,9 +335,25 @@ impl<'a> Petnames<'a> {
             .reduce(u128::saturating_mul)
             .unwrap_or(0u128)
     }
+
+    /// Create a [`Namer`] that generates petnames from these word lists.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+    /// let name = petname::Petnames::default()
+    ///     .namer(3, "-")
+    ///     .iter(&mut rand::rng())
+    ///     .next()
+    ///     .expect("no names");
+    /// ```
+    pub fn namer<'b>(&'b self, words: u8, separator: &'b str) -> Namer<'b, Self> {
+        Namer { generator: self, words, separator }
+    }
 }
 
-impl<'a> Generator<'a> for Petnames<'a> {
+impl Generator for Petnames<'_> {
     fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str) {
         for list in Lists::new(words) {
             match list {
@@ -416,6 +434,23 @@ impl Alliterations<'_> {
             .reduce(u128::saturating_add)
             .unwrap_or(0u128)
     }
+
+    /// Create a [`Namer`] that generates alliterative petnames from these word
+    /// lists.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+    /// let name = petname::Alliterations::default()
+    ///     .namer(3, "-")
+    ///     .iter(&mut rand::rng())
+    ///     .next()
+    ///     .expect("no names");
+    /// ```
+    pub fn namer<'b>(&'b self, words: u8, separator: &'b str) -> Namer<'b, Self> {
+        Namer { generator: self, words, separator }
+    }
 }
 
 impl<'a> From<Petnames<'a>> for Alliterations<'a> {
@@ -462,7 +497,7 @@ fn group_words_by_first_letter(words: Words<'_>) -> BTreeMap<char, Vec<&str>> {
     })
 }
 
-impl<'a> Generator<'a> for Alliterations<'a> {
+impl Generator for Alliterations<'_> {
     fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str) {
         if let Some(group) = self.groups.values().choose(rng) {
             group.generate_into(buf, rng, words, separator);
@@ -551,30 +586,6 @@ impl Iterator for Lists {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = self.remaining();
         (remaining, Some(remaining))
-    }
-}
-
-/// Iterator yielding petnames.
-struct Names<'a, GENERATOR>
-where
-    GENERATOR: Generator<'a>,
-{
-    generator: &'a GENERATOR,
-    rng: &'a mut dyn rand::Rng,
-    words: u8,
-    separator: &'a str,
-}
-
-impl<'a, GENERATOR> Iterator for Names<'a, GENERATOR>
-where
-    GENERATOR: Generator<'a>,
-{
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut buf = String::new();
-        self.generator.generate_into(&mut buf, self.rng, self.words, self.separator);
-        (!buf.is_empty()).then_some(buf)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,16 @@ impl Default for Petnames<'_> {
 }
 
 /// Word lists prepared for alliteration.
+///
+/// Construct from a [`Petnames`] with [`Alliterations::from`]. This takes that
+/// instance and splits it into several _groups_. In each, all of the nouns,
+/// adverbs, and adjectives will start with the same letter. A name generated
+/// from any of them will naturally produce an alliterative petname.
+///
+/// You can also create one of these from an iterable of `(char, Petnames)`.
+/// This might be useful for testing, or for repurposing this to generate names
+/// with assonance, say.
+///
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Alliterations<'a> {
     groups: BTreeMap<char, Petnames<'a>>,
@@ -351,6 +361,15 @@ pub struct Alliterations<'a> {
 
 impl Alliterations<'_> {
     /// Keep only those groups that match a predicate.
+    ///
+    /// A _group_ is defined by a [`char`] and a corresponding [`Petnames`]
+    /// instance.
+    ///
+    /// The given predicate can return `true` to keep the group or `false` to
+    /// evict it. It can also mutate each `Petnames` instance. The notional
+    /// invariant is that every noun, adverb, and adjective in that `Petnames`
+    /// instance should start with that `char`, but it's okay to break that.
+    ///
     pub fn retain<F>(&mut self, predicate: F)
     where
         F: FnMut(&char, &mut Petnames) -> bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,13 @@
 //! from [rand][]:
 //!
 //! ```rust
-//! use petname::Generator; // Trait needs to be in scope for `generate`.
-//! # #[cfg(feature = "default-rng")]
+//! use petname::Generator; // Trait needs to be in scope for `iter`.
+//! # #[cfg(feature = "default-rng")] {
 //! let mut rng = rand::rngs::ThreadRng::default();
-//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-//! let name = petname::Petnames::default().iter(&mut rng, 7, ":").next().expect("no names");
+//! # #[cfg(feature = "default-words")] {
+//! let petnames = petname::Petnames::default();
+//! let name = petnames.iter(&mut rng, 7, ":").next().expect("no names");
+//! # } }
 //! ```
 //!
 //! There's a [convenience function][petname()] that'll generate a single name
@@ -139,6 +141,28 @@ pub trait Generator<'a> {
     /// # }
     /// ```
     ///
+    /// When looping you might want to check if the buffer has been modified or
+    /// not. An unmodified buffer might mean that the source of names or
+    /// randomness has been exhausted.
+    ///
+    /// ```rust
+    /// # use petname::Generator;
+    /// let mut buf = String::new();
+    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
+    /// let petnames = petname::Petnames::default();
+    /// loop {
+    ///     petnames.generate_into(&mut buf, &mut rand::rng(), 3, "+");
+    ///     if buf.is_empty() {
+    ///         break;  // Source exhausted?
+    ///     } else {
+    ///         println!("Petname: {buf}");
+    ///         buf.clear();  // Reset before next iteration.
+    ///         # break;
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    ///
     /// # Notes
     ///
     /// This constructed name _may_ return fewer words than you request if one
@@ -150,8 +174,10 @@ pub trait Generator<'a> {
 
     /// Iterator yielding petnames.
     ///
-    /// A new [`String`] is allocated for each name yielded. See also the notes
-    /// on [`generate_into`][`Self::generate_into`].
+    /// Note that a new [`String`] is allocated for each name yielded. If this
+    /// is a problem, consider [`generate_into`][`Self::generate_into`] instead.
+    ///
+    /// See also the notes on [`generate_into`][`Self::generate_into`].
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,32 +121,43 @@ pub use petname_macros::petnames;
 /// Trait that defines a generator of petnames.
 ///
 /// There is a default implementation of [`iter`][`Self::iter`]; only
-/// [`generate_parts`][`Self::generate_parts`] needs to be implemented.
+/// [`generate_into`][`Self::generate_into`] needs to be implemented.
 ///
 pub trait Generator<'a> {
-    /// Generate the parts for a new petname.
+    /// Generate a petname into a given [`String`] buffer.
+    ///
+    /// This can be more efficient than [`iter`][`Self::iter`] when generating
+    /// many names because the buffer can be reused; `iter` creates a new
+    /// `String` on every iteration.
+    ///
+    /// This method does not clear the buffer. The generated name is pushed at
+    /// the end of the string.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use petname::Generator;
-    /// let mut buf: Vec<&str> = Vec::with_capacity(7);
+    /// let mut buf = String::new();
     /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
     /// let mut rng = rand::rngs::ThreadRng::default();
-    /// petname::Petnames::default().generate_parts(&mut buf, &mut rng, 7);
-    /// assert_eq!(7, buf.len());
+    /// petname::Petnames::default().generate_into(&mut buf, &mut rng, 7, "::".into());
+    /// assert_eq!(7, buf.split("::").count());
     /// # }
     /// ```
     ///
     /// # Notes
     ///
-    /// This may return fewer words than you request if one or more of the word
-    /// lists are empty. For example, if there are no adverbs, requesting 3 or
-    /// more words may still yield only `["doubtful", "salmon"]`.
+    /// This constructed name _may_ return fewer words than you request if one
+    /// or more of the word lists are empty. For example, if there are no
+    /// adverbs, requesting 3 or more words may still yield only `["doubtful",
+    /// "salmon"]`.
     ///
-    fn generate_parts(&self, buf: &mut Vec<&'a str>, rng: &mut dyn rand::Rng, words: u8);
+    fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str);
 
     /// Iterator yielding petnames.
+    ///
+    /// A new [`String`] is allocated for each name yielded. See also the notes
+    /// on [`generate_into`][`Self::generate_into`].
     ///
     /// # Examples
     ///
@@ -264,12 +275,28 @@ impl<'a> Petnames<'a> {
 }
 
 impl<'a> Generator<'a> for Petnames<'a> {
-    fn generate_parts(&self, buf: &mut Vec<&'a str>, rng: &mut dyn rand::Rng, words: u8) {
-        buf.extend(Lists::new(words).filter_map(|list| match list {
-            List::Adverb => self.adverbs.choose(rng).copied(),
-            List::Adjective => self.adjectives.choose(rng).copied(),
-            List::Noun => self.nouns.choose(rng).copied(),
-        }));
+    fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str) {
+        for list in Lists::new(words) {
+            match list {
+                List::Adverb => {
+                    if let Some(word) = self.adverbs.choose(rng).copied() {
+                        buf.push_str(word);
+                        buf.push_str(separator);
+                    }
+                }
+                List::Adjective => {
+                    if let Some(word) = self.adjectives.choose(rng).copied() {
+                        buf.push_str(word);
+                        buf.push_str(separator);
+                    }
+                }
+                List::Noun => {
+                    if let Some(word) = self.nouns.choose(rng).copied() {
+                        buf.push_str(word);
+                    }
+                }
+            };
+        }
     }
 }
 
@@ -356,27 +383,9 @@ fn group_words_by_first_letter(words: Words<'_>) -> BTreeMap<char, Vec<&str>> {
 }
 
 impl<'a> Generator<'a> for Alliterations<'a> {
-    /// Generate a new petname.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use petname::Generator;
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
-    /// let mut rng = rand::rngs::ThreadRng::default();
-    /// petname::Petnames::default().iter(&mut rng, 7, ":").next();
-    /// # }
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// This may return fewer words than you request if one or more of the word
-    /// lists are empty. For example, if there are no adverbs, requesting 3 or
-    /// more words may still yield only "doubtful-salmon".
-    ///
-    fn generate_parts(&self, buf: &mut Vec<&'a str>, rng: &mut dyn rand::Rng, words: u8) {
+    fn generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng, words: u8, separator: &str) {
         if let Some(group) = self.groups.values().choose(rng) {
-            group.generate_parts(buf, rng, words);
+            group.generate_into(buf, rng, words, separator);
         }
     }
 }
@@ -483,20 +492,9 @@ where
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut parts = Vec::with_capacity(self.words as usize);
-        self.generator.generate_parts(&mut parts, self.rng, self.words);
-        let mut parts = parts.iter();
-        if let Some(first) = parts.next() {
-            let mut buf = String::new();
-            buf.push_str(first);
-            for part in parts {
-                buf.push_str(&self.separator);
-                buf.push_str(part);
-            }
-            Some(buf)
-        } else {
-            None
-        }
+        let mut buf = String::new();
+        self.generator.generate_into(&mut buf, self.rng, self.words, &self.separator);
+        (!buf.is_empty()).then_some(buf)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,13 +94,7 @@ extern crate alloc;
 #[cfg(feature = "macros")]
 extern crate self as petname;
 
-use alloc::{
-    borrow::Cow,
-    boxed::Box,
-    collections::BTreeMap,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 
 use rand::seq::{IndexedRandom, IteratorRandom};
 
@@ -174,12 +168,12 @@ pub trait Generator<'a> {
         &'a self,
         rng: &'a mut dyn rand::Rng,
         words: u8,
-        separator: &str,
+        separator: &'a str,
     ) -> Box<dyn Iterator<Item = String> + 'a>
     where
         Self: Sized,
     {
-        let names = Names { generator: self, rng, words, separator: separator.to_string() };
+        let names = Names { generator: self, rng, words, separator };
         Box::new(names)
     }
 }
@@ -482,7 +476,7 @@ where
     generator: &'a GENERATOR,
     rng: &'a mut dyn rand::Rng,
     words: u8,
-    separator: String,
+    separator: &'a str,
 }
 
 impl<'a, GENERATOR> Iterator for Names<'a, GENERATOR>
@@ -493,7 +487,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut buf = String::new();
-        self.generator.generate_into(&mut buf, self.rng, self.words, &self.separator);
+        self.generator.generate_into(&mut buf, self.rng, self.words, self.separator);
         (!buf.is_empty()).then_some(buf)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,11 @@
 //! # #[cfg(feature = "default-rng")]
 //! let mut rng = rand::rngs::ThreadRng::default();
 //! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-//! let name = petname::Petnames::default().generate(&mut rng, 7, ":").expect("no names");
+//! let name = petname::Petnames::default().iter(&mut rng, 7, ":").next().expect("no names");
 //! ```
 //!
-//! It may be more convenient to use the default random number generator:
-//!
-//! ```rust
-//! use petname::Generator; // Trait needs to be in scope for `generate_one`.
-//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-//! let name = petname::Petnames::default().generate_one(7, ":").expect("no names");
-//! ```
-//!
-//! There's a [convenience function][petname()] that'll do all of this:
+//! There's a [convenience function][petname()] that'll generate a single name
+//! with a default random number generator:
 //!
 //! ```rust
 //! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
@@ -56,14 +49,13 @@
 //!
 //! ```rust
 //! # use petname::Generator;
-//! # #[cfg(feature = "default-words")]
+//! # #[cfg(feature = "default-words")] {
 //! let mut petnames = petname::Petnames::default();
-//! # #[cfg(feature = "default-words")]
 //! petnames.retain(|s| s.starts_with("b"));
-//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-//! let name = petnames.generate_one(3, ".").expect("no names");
-//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+//! # #[cfg(feature = "default-rng")] {
+//! let name = petnames.iter(&mut rand::rng(), 3, ".").next().expect("no names");
 //! assert!(name.starts_with('b'));
+//! # } }
 //! ```
 //!
 //! There's another way to generate alliterative petnames which is useful when
@@ -73,12 +65,12 @@
 //!
 //! ```rust
 //! # use petname::Generator;
-//! # #[cfg(feature = "default-words")]
+//! # #[cfg(feature = "default-words")] {
 //! let mut petnames = petname::Petnames::default();
-//! # #[cfg(feature = "default-words")]
 //! let mut alliterations: petname::Alliterations = petnames.into();
-//! # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-//! alliterations.generate_one(3, "/").expect("no names");
+//! # #[cfg(feature = "default-rng")]
+//! alliterations.iter(&mut rand::rng(), 3, "/").next().expect("no names");
+//! # }
 //! ```
 //!
 //! Both [`Petnames`] and [`Alliterations`] implement [`Generator`]; this needs
@@ -90,10 +82,10 @@
 //!
 //! ```rust
 //! use petname::Generator;
-//! # #[cfg(feature = "default-words")]
+//! # #[cfg(feature = "default-words")] {
 //! let generator: &dyn Generator = &petname::Petnames::default();
-//! # #[cfg(feature = "default-words")]
 //! let generator: &dyn Generator = &petname::Alliterations::default();
+//! # }
 //! ```
 //!
 
@@ -116,7 +108,7 @@ use rand::seq::{IndexedRandom, IteratorRandom};
 #[allow(dead_code)]
 #[cfg(all(feature = "default-rng", feature = "default-words"))]
 pub fn petname(words: u8, separator: &str) -> Option<String> {
-    Petnames::default().generate_one(words, separator)
+    Petnames::default().iter(&mut rand::rng(), words, separator).next()
 }
 
 /// A word list.
@@ -128,52 +120,22 @@ pub use petname_macros::petnames;
 
 /// Trait that defines a generator of petnames.
 ///
-/// There are default implementations of `generate`, `generate_one` and `iter`, i.e. only
-/// `generate_raw` needs to be implemented.
+/// There is a default implementation of [`iter`][`Self::iter`]; only
+/// [`generate_parts`][`Self::generate_parts`] needs to be implemented.
 ///
 pub trait Generator<'a> {
-    /// Generate a new petname.
+    /// Generate the parts for a new petname.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use petname::Generator;
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+    /// let mut buf: Vec<&str> = Vec::with_capacity(7);
+    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
     /// let mut rng = rand::rngs::ThreadRng::default();
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-    /// petname::Petnames::default().generate(&mut rng, 7, ":");
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// This may return fewer words than you request if one or more of the word
-    /// lists are empty. For example, if there are no adverbs, requesting 3 or
-    /// more words may still yield only "doubtful-salmon".
-    ///
-    fn generate(&self, rng: &mut dyn rand::Rng, words: u8, separator: &str) -> Option<String> {
-        self.generate_raw(rng, words).map(|x| x.join(separator))
-    }
-
-    /// Generate a single new petname.
-    ///
-    /// This is like `generate` but uses `rand::rngs::ThreadRng` as the random
-    /// source. For efficiency use `generate` when creating multiple names, or
-    /// when you want to use a custom source of randomness.
-    #[cfg(feature = "default-rng")]
-    fn generate_one(&self, words: u8, separator: &str) -> Option<String> {
-        self.generate(&mut rand::rng(), words, separator)
-    }
-
-    /// Generate a new petname and return the constituent words.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use petname::Generator;
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-    /// let mut rng = rand::rngs::ThreadRng::default();
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-    /// assert_eq!(7, petname::Petnames::default().generate_raw(&mut rng, 7).unwrap().len());
+    /// petname::Petnames::default().generate_parts(&mut buf, &mut rng, 7);
+    /// assert_eq!(7, buf.len());
+    /// # }
     /// ```
     ///
     /// # Notes
@@ -182,7 +144,7 @@ pub trait Generator<'a> {
     /// lists are empty. For example, if there are no adverbs, requesting 3 or
     /// more words may still yield only `["doubtful", "salmon"]`.
     ///
-    fn generate_raw(&self, rng: &mut dyn rand::Rng, words: u8) -> Option<Vec<&'a str>>;
+    fn generate_parts(&self, buf: &mut Vec<&'a str>, rng: &mut dyn rand::Rng, words: u8);
 
     /// Iterator yielding petnames.
     ///
@@ -190,14 +152,12 @@ pub trait Generator<'a> {
     ///
     /// ```rust
     /// # use petname::Generator;
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
     /// let mut rng = rand::rngs::ThreadRng::default();
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
     /// let petnames = petname::Petnames::default();
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
     /// let mut iter = petnames.iter(&mut rng, 4, "_");
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
     /// println!("name: {}", iter.next().unwrap());
+    /// # }
     /// ```
     fn iter(
         &'a self,
@@ -264,12 +224,12 @@ impl<'a> Petnames<'a> {
     ///
     /// ```rust
     /// # use petname::Generator;
-    /// # #[cfg(feature = "default-words")]
+    /// # #[cfg(feature = "default-words")] {
     /// let mut petnames = petname::Petnames::default();
-    /// # #[cfg(feature = "default-words")]
     /// petnames.retain(|s| s.starts_with("h"));
-    /// # #[cfg(all(feature = "default-words", feature = "default-rng"))]
-    /// assert!(petnames.generate_one(2, ".").unwrap().starts_with('h'));
+    /// # #[cfg(feature = "default-rng")]
+    /// assert!(petnames.iter(&mut rand::rng(), 2, ".").next().unwrap().starts_with('h'));
+    /// # }
     /// ```
     ///
     /// This is a convenience wrapper that applies the same predicate to the
@@ -304,19 +264,12 @@ impl<'a> Petnames<'a> {
 }
 
 impl<'a> Generator<'a> for Petnames<'a> {
-    fn generate_raw(&self, rng: &mut dyn rand::Rng, words: u8) -> Option<Vec<&'a str>> {
-        let name = Lists::new(words)
-            .filter_map(|list| match list {
-                List::Adverb => self.adverbs.choose(rng).copied(),
-                List::Adjective => self.adjectives.choose(rng).copied(),
-                List::Noun => self.nouns.choose(rng).copied(),
-            })
-            .collect::<Vec<_>>();
-        if name.is_empty() {
-            None
-        } else {
-            Some(name)
-        }
+    fn generate_parts(&self, buf: &mut Vec<&'a str>, rng: &mut dyn rand::Rng, words: u8) {
+        buf.extend(Lists::new(words).filter_map(|list| match list {
+            List::Adverb => self.adverbs.choose(rng).copied(),
+            List::Adjective => self.adjectives.choose(rng).copied(),
+            List::Noun => self.nouns.choose(rng).copied(),
+        }));
     }
 }
 
@@ -409,10 +362,10 @@ impl<'a> Generator<'a> for Alliterations<'a> {
     ///
     /// ```rust
     /// # use petname::Generator;
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
+    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
     /// let mut rng = rand::rngs::ThreadRng::default();
-    /// # #[cfg(all(feature = "default-rng", feature = "default-words"))]
-    /// petname::Petnames::default().generate(&mut rng, 7, ":");
+    /// petname::Petnames::default().iter(&mut rng, 7, ":").next();
+    /// # }
     /// ```
     ///
     /// # Notes
@@ -421,8 +374,10 @@ impl<'a> Generator<'a> for Alliterations<'a> {
     /// lists are empty. For example, if there are no adverbs, requesting 3 or
     /// more words may still yield only "doubtful-salmon".
     ///
-    fn generate_raw(&self, rng: &mut dyn rand::Rng, words: u8) -> Option<Vec<&'a str>> {
-        self.groups.values().choose(rng).and_then(|group| group.generate_raw(rng, words))
+    fn generate_parts(&self, buf: &mut Vec<&'a str>, rng: &mut dyn rand::Rng, words: u8) {
+        if let Some(group) = self.groups.values().choose(rng) {
+            group.generate_parts(buf, rng, words);
+        }
     }
 }
 
@@ -528,7 +483,20 @@ where
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.generator.generate(self.rng, self.words, &self.separator)
+        let mut parts = Vec::with_capacity(self.words as usize);
+        self.generator.generate_parts(&mut parts, self.rng, self.words);
+        let mut parts = parts.iter();
+        if let Some(first) = parts.next() {
+            let mut buf = String::new();
+            buf.push_str(first);
+            for part in parts {
+                buf.push_str(&self.separator);
+                buf.push_str(part);
+            }
+            Some(buf)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub trait Generator<'a> {
     /// let mut buf = String::new();
     /// # #[cfg(all(feature = "default-rng", feature = "default-words"))] {
     /// let mut rng = rand::rngs::ThreadRng::default();
-    /// petname::Petnames::default().generate_into(&mut buf, &mut rng, 7, "::".into());
+    /// petname::Petnames::default().generate_into(&mut buf, &mut rng, 7, "::");
     /// assert_eq!(7, buf.split("::").count());
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,19 +91,11 @@
 //! # The [`Generator`] trait
 //!
 //! Both [`Petnames`] and [`Alliterations`] implement [`Generator`]; this needs
-//! to be in scope in order to generate names. It's [object-safe] so you can use
-//! `Petnames` and `Alliterations` as trait objects:
+//! to be in scope in order to generate names. There are some caveats around its
+//! [object-safety][], so read the trait docs if that affects you.
 //!
-//! [object-safe]:
+//! [object-safety]:
 //!     https://doc.rust-lang.org/reference/items/traits.html#object-safety
-//!
-//! ```rust
-//! use petname::Generator;
-//! # #[cfg(feature = "default-words")] {
-//! let generator: &dyn Generator = &petname::Petnames::default();
-//! let generator: &dyn Generator = &petname::Alliterations::default();
-//! # }
-//! ```
 //!
 
 extern crate alloc;
@@ -133,6 +125,40 @@ pub use petname_macros::petnames;
 ///
 /// There is a default implementation of [`iter`][`Self::iter`]; only
 /// [`generate_into`][`Self::generate_into`] needs to be implemented.
+///
+/// This is _somewhat_ [object-safe] so you can use [`Petnames`] and
+/// [`Alliterations`] as trait objects. The _somewhat_ is because only
+/// [`generate_into`][`Self::generate_into`] will be usable; trying to call
+/// [`iter`][`Self::iter`] on a trait object will not compile.
+///
+/// [object-safe]:
+///     https://doc.rust-lang.org/reference/items/traits.html#object-safety
+///
+/// Here, `generate_into` is fine:
+///
+/// ```rust
+/// use petname::Generator;
+/// let mut buf = String::new();
+/// # #[cfg(all(feature = "default-words", feature = "default-rng"))] {
+/// let petnames: &dyn Generator = &petname::Petnames::default();
+/// petnames.generate_into(&mut buf, &mut rand::rng(), 3, "/");
+/// let alliterations: &dyn Generator = &petname::Alliterations::default();
+/// alliterations.generate_into(&mut buf, &mut rand::rng(), 3, "/");
+/// # }
+/// ```
+///
+/// But `iter` does **not work**:
+///
+/// ```compile_fail
+/// use petname::Generator;
+/// let mut buf = String::new();
+/// # #[cfg(all(feature = "default-words", feature = "default-rng"))] {
+/// let petnames: &dyn Generator = &petname::Petnames::default();
+/// petnames.iter(&mut rand::rng(), 3, "/").next().expect("no names");
+/// let alliterations: &dyn Generator = &petname::Alliterations::default();
+/// alliterations.iter(&mut rand::rng(), 3, "/").next().expect("no names");
+/// # }
+/// ```
 ///
 pub trait Generator<'a> {
     /// Generate a petname into a given [`String`] buffer.

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ where
         if alliterations.cardinality(cli.words) == 0 {
             return Err(Error::Alliteration("word lists have no initial letters in common".to_string()));
         }
-        printer(writer, alliterations.iter(&mut rng, cli.words, &cli.separator), count)
+        printer(writer, alliterations, &mut rng, cli.words, &cli.separator, count)
     } else if let Some(alliterate_with) = cli.alliterate_with {
         let mut alliterations: Alliterations = petnames.into();
         alliterations.retain(|first_letter, group| {
@@ -124,26 +124,45 @@ where
                 "no petnames begin with the chosen alliteration character".to_string(),
             ));
         }
-        printer(writer, alliterations.iter(&mut rng, cli.words, &cli.separator), count)
+        printer(writer, alliterations, &mut rng, cli.words, &cli.separator, count)
     } else {
-        printer(writer, petnames.iter(&mut rng, cli.words, &cli.separator), count)
+        printer(writer, petnames, &mut rng, cli.words, &cli.separator, count)
     }
 }
 
-fn printer<OUT, NAMES>(writer: &mut OUT, names: NAMES, count: Option<usize>) -> Result<(), Error>
+fn printer<'a, OUT, GENERATOR, RNG>(
+    writer: &mut OUT,
+    generator: GENERATOR,
+    rng: &mut RNG,
+    words: u8,
+    separator: &str,
+    count: Option<usize>,
+) -> Result<(), Error>
 where
     OUT: io::Write,
-    NAMES: Iterator<Item = String>,
+    GENERATOR: Generator<'a>,
+    RNG: rand::Rng,
 {
+    let mut buf = String::new();
     match count {
-        None => {
-            for name in names {
-                writeln!(writer, "{name}").map_err(suppress_disconnect)?;
+        None => loop {
+            generator.generate_into(&mut buf, rng, words, separator);
+            if buf.is_empty() {
+                break;
+            } else {
+                writeln!(writer, "{buf}").map_err(suppress_disconnect)?;
+                buf.clear();
             }
-        }
+        },
         Some(n) => {
-            for name in names.take(n) {
-                writeln!(writer, "{name}")?;
+            for _ in 0..n {
+                generator.generate_into(&mut buf, rng, words, separator);
+                if buf.is_empty() {
+                    break;
+                } else {
+                    writeln!(writer, "{buf}")?;
+                    buf.clear();
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod cli;
 
 use cli::Cli;
 use petname::Alliterations;
-use petname::{Generator, Petnames};
+use petname::{Generator, Namer, Petnames};
 
 use std::fmt;
 use std::fs;
@@ -113,7 +113,7 @@ where
         if alliterations.cardinality(cli.words) == 0 {
             return Err(Error::Alliteration("word lists have no initial letters in common".to_string()));
         }
-        printer(writer, alliterations, &mut rng, cli.words, &cli.separator, count)
+        printer(writer, &alliterations.namer(cli.words, &cli.separator), &mut rng, count)
     } else if let Some(alliterate_with) = cli.alliterate_with {
         let mut alliterations: Alliterations = petnames.into();
         alliterations.retain(|first_letter, group| {
@@ -124,29 +124,27 @@ where
                 "no petnames begin with the chosen alliteration character".to_string(),
             ));
         }
-        printer(writer, alliterations, &mut rng, cli.words, &cli.separator, count)
+        printer(writer, &alliterations.namer(cli.words, &cli.separator), &mut rng, count)
     } else {
-        printer(writer, petnames, &mut rng, cli.words, &cli.separator, count)
+        printer(writer, &petnames.namer(cli.words, &cli.separator), &mut rng, count)
     }
 }
 
-fn printer<'a, OUT, GENERATOR, RNG>(
+fn printer<OUT, GEN, RNG>(
     writer: &mut OUT,
-    generator: GENERATOR,
+    namer: &Namer<'_, GEN>,
     rng: &mut RNG,
-    words: u8,
-    separator: &str,
     count: Option<usize>,
 ) -> Result<(), Error>
 where
     OUT: io::Write,
-    GENERATOR: Generator<'a>,
+    GEN: Generator,
     RNG: rand::Rng,
 {
     let mut buf = String::new();
     match count {
         None => loop {
-            generator.generate_into(&mut buf, rng, words, separator);
+            namer.generate_into(&mut buf, rng);
             if buf.is_empty() {
                 break;
             } else {
@@ -156,7 +154,7 @@ where
         },
         Some(n) => {
             for _ in 0..n {
-                generator.generate_into(&mut buf, rng, words, separator);
+                namer.generate_into(&mut buf, rng);
                 if buf.is_empty() {
                     break;
                 } else {

--- a/tests/alliterations.rs
+++ b/tests/alliterations.rs
@@ -44,7 +44,7 @@ fn alliterations_generate_uses_adverb_adjective_name() {
     let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
     let alliterations: Alliterations = petnames.into();
     assert_eq!(
-        alliterations.generate(&mut mocks::StepRng::new(6234567891, 1), 3, "-"),
+        alliterations.iter(&mut mocks::StepRng::new(6234567891, 1), 3, "-").next(),
         Some("burly-bold-bee".into())
     );
 }

--- a/tests/alliterations.rs
+++ b/tests/alliterations.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use petname::{Alliterations, Generator, Petnames};
+use petname::{Alliterations, Petnames};
 
 mod mocks;
 
@@ -44,7 +44,7 @@ fn alliterations_generate_uses_adverb_adjective_name() {
     let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
     let alliterations: Alliterations = petnames.into();
     assert_eq!(
-        alliterations.iter(&mut mocks::StepRng::new(6234567891, 1), 3, "-").next(),
+        alliterations.namer(3, "-").iter(&mut mocks::StepRng::new(6234567891, 1)).next(),
         Some("burly-bold-bee".into())
     );
 }
@@ -54,7 +54,8 @@ fn alliterations_iter_yields_names() {
     let mut rng = mocks::StepRng::new(1234567890, 1234567890);
     let petnames = Petnames::new("able bold", "burly curly", "ant bee cow");
     let alliterations: Alliterations = petnames.into();
-    let names = alliterations.iter(&mut rng, 3, " ");
+    let namer = alliterations.namer(3, " ");
+    let names = namer.iter(&mut rng);
     let expected: HashSet<String> = ["able ant", "burly bold bee", "curly cow"].map(String::from).into();
     let observed: HashSet<String> = names.take(10).collect::<HashSet<String>>();
     assert_eq!(expected, observed);
@@ -65,6 +66,7 @@ fn alliterations_iter_yields_nothing_when_empty() {
     let mut rng = mocks::StepRng::new(0, 1);
     let alliteration: Alliterations = [].into();
     assert_eq!(0, alliteration.cardinality(3));
-    let mut names: Box<dyn Iterator<Item = _>> = alliteration.iter(&mut rng, 3, ".");
+    let namer = alliteration.namer(3, ".");
+    let mut names = namer.iter(&mut rng);
     assert_eq!(None, names.next());
 }

--- a/tests/petnames.rs
+++ b/tests/petnames.rs
@@ -74,12 +74,11 @@ fn petnames_iter_yields_nothing_when_empty() {
 }
 
 #[test]
-fn petnames_raw_works() {
+fn petnames_generate_into_works() {
     let mut rng = mocks::StepRng::new(0, 1);
-    let words = [":?-_", "_?:-", "-:_?"];
+    let words = ["adj", "adv", "noun"];
     let petnames = Petnames::new(words[0], words[1], words[2]);
-    let mut buf = Vec::new();
-    petnames.generate_parts(&mut buf, &mut rng, 3);
-    assert_eq!(3, buf.len());
-    assert_eq!(vec![words[1], words[0], words[2]], buf);
+    let mut buf = String::new();
+    petnames.generate_into(&mut buf, &mut rng, 3, " ");
+    assert_eq!("adv adj noun", &buf);
 }

--- a/tests/petnames.rs
+++ b/tests/petnames.rs
@@ -51,7 +51,7 @@ fn petnames_generate_uses_adverb_adjective_name() {
         nouns: vec!["noun"].into(),
     };
     assert_eq!(
-        petnames.generate(&mut mocks::StepRng::new(0, 1), 3, "-"),
+        petnames.iter(&mut mocks::StepRng::new(0, 1), 3, "-").next(),
         Some("adverb-adjective-noun".into())
     );
 }
@@ -78,7 +78,8 @@ fn petnames_raw_works() {
     let mut rng = mocks::StepRng::new(0, 1);
     let words = [":?-_", "_?:-", "-:_?"];
     let petnames = Petnames::new(words[0], words[1], words[2]);
-    let result = petnames.generate_raw(&mut rng, 3).unwrap();
-    assert_eq!(3, result.len());
-    assert_eq!(vec![words[1], words[0], words[2]], result);
+    let mut buf = Vec::new();
+    petnames.generate_parts(&mut buf, &mut rng, 3);
+    assert_eq!(3, buf.len());
+    assert_eq!(vec![words[1], words[0], words[2]], buf);
 }

--- a/tests/petnames.rs
+++ b/tests/petnames.rs
@@ -1,4 +1,4 @@
-use petname::{Generator, Petnames};
+use petname::Petnames;
 
 mod mocks;
 
@@ -51,7 +51,7 @@ fn petnames_generate_uses_adverb_adjective_name() {
         nouns: vec!["noun"].into(),
     };
     assert_eq!(
-        petnames.iter(&mut mocks::StepRng::new(0, 1), 3, "-").next(),
+        petnames.namer(3, "-").iter(&mut mocks::StepRng::new(0, 1)).next(),
         Some("adverb-adjective-noun".into())
     );
 }
@@ -60,7 +60,8 @@ fn petnames_generate_uses_adverb_adjective_name() {
 fn petnames_iter_yields_names() {
     let mut rng = mocks::StepRng::new(0, 1);
     let petnames = Petnames::new("foo", "bar", "baz");
-    let mut names: Box<dyn Iterator<Item = _>> = petnames.iter(&mut rng, 3, ".");
+    let namer = petnames.namer(3, ".");
+    let mut names = namer.iter(&mut rng);
     assert_eq!(Some("bar.foo.baz".to_string()), names.next());
 }
 
@@ -69,7 +70,8 @@ fn petnames_iter_yields_nothing_when_empty() {
     let mut rng = mocks::StepRng::new(0, 1);
     let petnames = Petnames::new("", "", "");
     assert_eq!(0, petnames.cardinality(3));
-    let mut names: Box<dyn Iterator<Item = _>> = petnames.iter(&mut rng, 3, ".");
+    let namer = petnames.namer(3, ".");
+    let mut names = namer.iter(&mut rng);
     assert_eq!(None, names.next());
 }
 
@@ -79,6 +81,6 @@ fn petnames_generate_into_works() {
     let words = ["adj", "adv", "noun"];
     let petnames = Petnames::new(words[0], words[1], words[2]);
     let mut buf = String::new();
-    petnames.generate_into(&mut buf, &mut rng, 3, " ");
+    petnames.namer(3, " ").generate_into(&mut buf, &mut rng);
     assert_eq!("adv adj noun", &buf);
 }


### PR DESCRIPTION
This is a significant redesign of the `Generator` trait and related APIs, targeting performance and ergonomics for 3.0.0.

### `generate_into` replaces piecemeal generation

Previously, generating a name involved multiple allocations – one per word part. The new `Generator::generate_into` writes directly into a caller-supplied `String` buffer, eliminating all intermediate allocations. In the CLI this yields a **1.7× speedup**.

`Generator` remains object-safe; `generate_into` takes `&mut dyn rand::Rng`.

### New `Namer` type

`Petnames::namer` and `Alliterations::namer` return a `Namer` – a lightweight config struct holding a reference to the word lists, a word count, and a separator. `Namer` provides two methods:

- `generate_into(&self, buf: &mut String, rng: &mut dyn rand::Rng)` – writes into a buffer directly; the most efficient option when generating many names.
- `iter(&self, rng: &mut dyn rand::Rng) -> impl Iterator<Item = String>` – yields owned `String`s; ergonomic for one-shot or iterator-chained use.

No trait import is required to call either method.

### Removed

- `Generator::iter` (moved to `Namer`).
- `Names` type (replaced by `Namer`).
- All other generator methods that have been superseded.

### Testing

`cargo hack` is now used in CI to test all feature-flag combinations.

### Documentation

- Module intro substantially rewritten for new users.
- `Alliterations` docs fleshed out.
- README upgrade notes updated for 2.x → 3.x migration.
