### PR TITLE
GH Actions workflows for macOS build/release

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,4 +1,4 @@
-name: rust-petname CI
+name: rust-petname CI (macOS)
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -20,7 +20,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -30,7 +30,7 @@ jobs:
 
   clippy:
     name: Clippy # i.e. `cargo check` plus extra linting.
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,29 @@
+name: macOS release
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers on tags like v1.0.0, v0.1.0-alpha, etc.
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish for macOS
+    runs-on: macos-latest
+    
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-hack
+      - run: cargo hack --workspace --feature-powerset build --release
+      - name: Package Binary
+        run: |
+          cd target/release
+          tar -czf rust-petname_darwin_arm64.tar.gz petname
+      - name: Upload to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        run: |
+          cd target/release
+          gh release upload ${{ github.ref_name }} rust-petname_darwin_arm64.tar.gz --clobber || \
+          gh release create ${{ github.ref_name }} rust-petname_darwin_arm64.tar.gz --title "Release ${{ github.ref_name }}" --draft=false


### PR DESCRIPTION
Add Github Actions workflows to build/release macOS binaries to make available to macOS users without Rust.